### PR TITLE
Ubuntu 24 / GCC 13 compilation fix

### DIFF
--- a/peer_connection.cpp
+++ b/peer_connection.cpp
@@ -18,6 +18,7 @@
 
 #include <cassert>
 #include <chrono>
+#include <unistd.h>
 
 #include <sys/eventfd.h>
 #include <sys/epoll.h>


### PR DESCRIPTION
"peer_connection.cpp:54:13: error: ‘close’ was not declared in this scope; did you mean ‘pclose’?"