### PR TITLE
Replay protection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED YES)
 
 include(ExternalProject)
+include(FetchContent)
 
 # srtc
 
@@ -27,6 +28,7 @@ add_library(srtc
         include/srtc/peer_candidate_listener.h
         include/srtc/peer_connection.h
         include/srtc/random_generator.h
+        include/srtc/replay_protection.h
         include/srtc/rtp_packet.h
         include/srtc/rtp_packet_source.h
         include/srtc/scheduler.h
@@ -52,6 +54,7 @@ add_library(srtc
         peer_candidate.cpp
         peer_connection.cpp
         random_generator.cpp
+        replay_protection.cpp
         rtp_packet.cpp
         rtp_packet_source.cpp
         sdp_answer.cpp
@@ -135,7 +138,7 @@ ExternalProject_Add(
 target_include_directories(srtc PRIVATE
         "${CMAKE_CURRENT_BINARY_DIR}/external/libsrtp/include")
 
-target_link_directories(srtc PRIVATE
+target_link_directories(srtc PUBLIC
         "${CMAKE_CURRENT_BINARY_DIR}/srtp-prefix/src/srtp-build")
 
 add_dependencies(srtc srtp)
@@ -151,3 +154,38 @@ target_include_directories(srtc PRIVATE
 
 target_link_directories(srtc PUBLIC
         "${CMAKE_BINARY_DIR}/srtc/stun")
+
+# Google Test
+
+FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+)
+
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+# Test executable
+
+add_executable(
+        srtc_test
+        EXCLUDE_FROM_ALL
+        test_replay_protection.cpp
+)
+target_include_directories(
+        srtc_test
+        PRIVATE
+        include
+)
+add_dependencies(srtc_test srtc srtp)
+target_link_libraries(
+        srtc_test
+        GTest::gtest_main
+        srtc
+        srtp3
+)
+
+if(NOT ANDROID)
+    include(GoogleTest)
+    gtest_discover_tests(srtc_test)
+endif()

--- a/byte_buffer.cpp
+++ b/byte_buffer.cpp
@@ -72,8 +72,22 @@ bool ByteBuffer::empty() const
 void ByteBuffer::clear()
 {
     delete[] mBuf;
+    mBuf = nullptr;
     mLen = 0;
     mCap = 0;
+}
+
+void ByteBuffer::assign(const uint8_t* src, size_t size)
+{
+    delete[] mBuf;
+    if (size) {
+        mBuf = new uint8_t[size];
+        std::memcpy(mBuf, src, size);
+    } else {
+        mBuf = nullptr;
+    }
+    mLen = size;
+    mCap =  size;
 }
 
 void ByteBuffer::resize(size_t size)

--- a/include/srtc/byte_buffer.h
+++ b/include/srtc/byte_buffer.h
@@ -25,6 +25,7 @@ public:
     [[nodiscard]] bool empty() const;
 
     void clear();
+    void assign(const uint8_t* src, size_t size);
     void resize(size_t size);
     void reserve(size_t size);
     void append(const uint8_t* src, size_t size);

--- a/include/srtc/replay_protection.h
+++ b/include/srtc/replay_protection.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+
+namespace srtc {
+
+class ReplayProtection final {
+public:
+    ReplayProtection(uint32_t maxPossibleValue,
+                     uint32_t size);
+    ~ReplayProtection();
+
+    [[nodiscard]] bool canProceed(uint32_t value);
+    bool set(uint32_t value);
+
+private:
+    const uint32_t mMaxPossibleValue;
+    const uint32_t mSize;
+    const uint32_t mStorageSize;
+    const uint32_t mMaxDistanceForward;
+
+    uint32_t mCurMax;
+    uint8_t* mStorage;
+
+    void setForward(uint32_t value);
+};
+
+}

--- a/include/srtc/replay_protection.h
+++ b/include/srtc/replay_protection.h
@@ -11,7 +11,7 @@ public:
     ~ReplayProtection();
 
     [[nodiscard]] bool canProceed(uint32_t value);
-    bool set(uint32_t value);
+    [[nodiscard]] bool set(uint32_t value);
 
 private:
     const uint32_t mMaxPossibleValue;

--- a/replay_protection.cpp
+++ b/replay_protection.cpp
@@ -45,7 +45,7 @@ ReplayProtection::ReplayProtection(uint32_t maxPossibleValue,
                                    uint32_t size)
     : mMaxPossibleValue(maxPossibleValue)
     , mSize(size)
-    , mStorageSize((size + 7) / 8)
+    , mStorageSize((size + 8 - 1) / 8)
     , mMaxDistanceForward(size / 4)
     , mStorage(nullptr)
     , mCurMax(0)    // not used until we allocate mStorage
@@ -114,7 +114,7 @@ bool ReplayProtection::set(uint32_t value)
         setForward(value);
         return true;
     } else {
-        const auto distance = mMaxPossibleValue - mCurMax + 1 + value;
+        const auto distance = mCurMax - value;
         if (distance >= mSize) {
             return false;
         }

--- a/replay_protection.cpp
+++ b/replay_protection.cpp
@@ -5,7 +5,7 @@
 
 namespace {
 
-uint32_t getForwadDistance(uint32_t maxPossibleValue, uint32_t curMaxValue, uint32_t value)
+uint32_t getRolloverForwadDistance(uint32_t maxPossibleValue, uint32_t curMaxValue, uint32_t value)
 {
     assert(curMaxValue > value);
     return maxPossibleValue - curMaxValue + 1 + value;
@@ -70,7 +70,7 @@ bool ReplayProtection::canProceed(uint32_t value)
             return false;
         }
         return true;
-    } else if (getForwadDistance(mMaxPossibleValue, mCurMax, value) <= mMaxDistanceForward) {
+    } else if (getRolloverForwadDistance(mMaxPossibleValue, mCurMax, value) <= mMaxDistanceForward) {
         return true;
     } else {
         const auto distance = mCurMax - value;
@@ -104,7 +104,7 @@ bool ReplayProtection::set(uint32_t value)
 
         setForward(value);
         return true;
-    } else if (getForwadDistance(mMaxPossibleValue, mCurMax, value) <= mMaxDistanceForward) {
+    } else if (getRolloverForwadDistance(mMaxPossibleValue, mCurMax, value) <= mMaxDistanceForward) {
         setForward(value);
         return true;
     } else {

--- a/replay_protection.cpp
+++ b/replay_protection.cpp
@@ -13,24 +13,24 @@ uint32_t getForwadDistance(uint32_t maxPossibleValue, uint32_t curMaxValue, uint
 
 bool isSet(const uint8_t* storage, uint32_t storageSize, uint32_t value)
 {
-    const auto index = (value % 8) % storageSize;
-    const auto shift = value % 7;
+    const auto index = (value / 8) % storageSize;
+    const auto shift = value % (8 - 1);
 
     return (storage[index] & (1 << shift)) != 0;
 }
 
 void setImpl(uint8_t* storage, uint32_t storageSize, uint32_t value)
 {
-    const auto index = (value % 8) % storageSize;;
-    const auto shift = value % 7;
+    const auto index = (value / 8) % storageSize;;
+    const auto shift = value % (8 - 1);
 
     storage[index] |= (1 << shift);
 }
 
 void clearImpl(uint8_t* storage, uint32_t storageSize, uint32_t value)
 {
-    const auto index = (value % 8) % storageSize;;
-    const auto shift = value % 7;
+    const auto index = (value / 8) % storageSize;;
+    const auto shift = value % (8 - 1);
 
     storage[index] &= ~(1 << shift);
 }

--- a/replay_protection.cpp
+++ b/replay_protection.cpp
@@ -7,7 +7,7 @@ namespace {
 
 uint32_t getForwadDistance(uint32_t maxPossibleValue, uint32_t curMaxValue, uint32_t value)
 {
-    assert(curMaxValue >= value);
+    assert(curMaxValue > value);
     return maxPossibleValue - curMaxValue + 1 + value;
 }
 

--- a/replay_protection.cpp
+++ b/replay_protection.cpp
@@ -3,6 +3,8 @@
 #include <cassert>
 #include <cstring>
 
+#include <limits>
+
 namespace {
 
 uint32_t getRolloverForwadDistance(uint32_t maxPossibleValue, uint32_t curMaxValue, uint32_t value)
@@ -48,6 +50,10 @@ ReplayProtection::ReplayProtection(uint32_t maxPossibleValue,
     , mStorage(nullptr)
     , mCurMax(0)    // not used until we allocate mStorage
 {
+    assert(
+            maxPossibleValue == std::numeric_limits<uint16_t>::max() ||
+            maxPossibleValue == std::numeric_limits<uint32_t>::max()
+            );
     assert(size <= 4096);
 }
 
@@ -120,10 +126,10 @@ bool ReplayProtection::set(uint32_t value)
 
 void ReplayProtection::setForward(uint32_t value)
 {
-    mCurMax = (mCurMax + 1) % (mMaxPossibleValue + 1);
+    mCurMax = (mCurMax + 1) & mMaxPossibleValue;
     while (mCurMax != value) {
         clearImpl(mStorage, mStorageSize, mCurMax);
-        mCurMax = (mCurMax + 1) % (mMaxPossibleValue + 1);
+        mCurMax = (mCurMax + 1) & mMaxPossibleValue;
     }
 
     setImpl(mStorage, mStorageSize, mCurMax);

--- a/replay_protection.cpp
+++ b/replay_protection.cpp
@@ -1,0 +1,132 @@
+#include "srtc/replay_protection.h"
+
+#include <cassert>
+#include <cstring>
+
+namespace {
+
+uint32_t getForwadDistance(uint32_t maxPossibleValue, uint32_t curMaxValue, uint32_t value)
+{
+    assert(curMaxValue >= value);
+    return maxPossibleValue - curMaxValue + 1 + value;
+}
+
+bool isSet(const uint8_t* storage, uint32_t storageSize, uint32_t value)
+{
+    const auto index = (value % 8) % storageSize;
+    const auto shift = value % 7;
+
+    return (storage[index] & (1 << shift)) != 0;
+}
+
+void setImpl(uint8_t* storage, uint32_t storageSize, uint32_t value)
+{
+    const auto index = (value % 8) % storageSize;;
+    const auto shift = value % 7;
+
+    storage[index] |= (1 << shift);
+}
+
+void clearImpl(uint8_t* storage, uint32_t storageSize, uint32_t value)
+{
+    const auto index = (value % 8) % storageSize;;
+    const auto shift = value % 7;
+
+    storage[index] &= ~(1 << shift);
+}
+
+}
+
+namespace srtc {
+
+ReplayProtection::ReplayProtection(uint32_t maxPossibleValue,
+                                   uint32_t size)
+    : mMaxPossibleValue(maxPossibleValue)
+    , mSize(size)
+    , mStorageSize((size + 7) / 8)
+    , mMaxDistanceForward(size / 4)
+    , mStorage(nullptr)
+    , mCurMax(0)    // not used until we allocate mStorage
+{
+    assert(size <= 4096);
+}
+
+ReplayProtection::~ReplayProtection()
+{
+    delete[] mStorage;
+}
+
+bool ReplayProtection::canProceed(uint32_t value)
+{
+    if (!mStorage) {
+        return true;
+    }
+
+    if (value == mCurMax) {
+        return false;
+    } else if (value > mCurMax) {
+        const auto distance = value - mCurMax;
+        if (distance > mMaxDistanceForward) {
+            return false;
+        }
+        return true;
+    } else if (getForwadDistance(mMaxPossibleValue, mCurMax, value) <= mMaxDistanceForward) {
+        return true;
+    } else {
+        const auto distance = mCurMax - value;
+        if (distance >= mSize) {
+            return false;
+        }
+
+        return !isSet(mStorage, mStorageSize, value);
+    }
+}
+
+bool ReplayProtection::set(uint32_t value)
+{
+    assert(canProceed(value));
+
+    if (!mStorage) {
+        mStorage = new uint8_t[mStorageSize];
+        std::memset(mStorage, 0, mStorageSize);
+        setImpl(mStorage, mStorageSize, value);
+        mCurMax = value;
+        return true;
+    }
+
+    if (value == mCurMax) {
+        return false;
+    } else if (value > mCurMax) {
+        const auto distance = value - mCurMax;
+        if (distance > mMaxDistanceForward) {
+            return false;
+        }
+
+        setForward(value);
+        return true;
+    } else if (getForwadDistance(mMaxPossibleValue, mCurMax, value) <= mMaxDistanceForward) {
+        setForward(value);
+        return true;
+    } else {
+        const auto distance = mMaxPossibleValue - mCurMax + 1 + value;
+        if (distance >= mSize) {
+            return false;
+        }
+
+        setImpl(mStorage, mStorageSize, value);
+        return true;
+    }
+}
+
+void ReplayProtection::setForward(uint32_t value)
+{
+    mCurMax = (mCurMax + 1) % (mMaxPossibleValue + 1);
+    while (mCurMax != value) {
+        clearImpl(mStorage, mStorageSize, mCurMax);
+        mCurMax = (mCurMax + 1) % (mMaxPossibleValue + 1);
+    }
+
+    setImpl(mStorage, mStorageSize, mCurMax);
+}
+
+}

--- a/test_replay_protection.cpp
+++ b/test_replay_protection.cpp
@@ -116,11 +116,11 @@ TEST(ReplayProtection, TestTooMuchForwardSimple)
     }
 }
 
-TEST(ReplayProtection, TestTooMuchForwardSimpleWithRollover)
+TEST(ReplayProtection, TestRollover16)
 {
     srtc::ReplayProtection replay_16(std::numeric_limits<uint16_t>::max(), kSize);
     {
-        uint16_t value = 65500;
+        const auto value = std::numeric_limits<uint16_t>::max() - 100;
         replay_16.set(value);
 
         ASSERT_FALSE(replay_16.canProceed(
@@ -137,5 +137,29 @@ TEST(ReplayProtection, TestTooMuchForwardSimpleWithRollover)
                 static_cast<uint16_t>(value + kSize / 4)));
         ASSERT_FALSE(replay_16.canProceed(
                 static_cast<uint16_t>(value + kSize / 4)));
+    }
+}
+
+TEST(ReplayProtection, TestRollover32)
+{
+    srtc::ReplayProtection replay_32(std::numeric_limits<uint32_t>::max(), kSize);
+    {
+        uint32_t value = std::numeric_limits<uint32_t>::max() - 100;
+        replay_32.set(value);
+
+        ASSERT_FALSE(replay_32.canProceed(
+                static_cast<uint32_t>(value + kSize / 2)));
+        ASSERT_FALSE(replay_32.canProceed(
+                static_cast<uint32_t>(value - kSize)));
+
+        ASSERT_TRUE(replay_32.canProceed(
+                static_cast<uint32_t>(value + kSize / 4)));
+        ASSERT_TRUE(replay_32.canProceed(
+                static_cast<uint32_t>(value - kSize + 1)));
+
+        ASSERT_TRUE(replay_32.set(
+                static_cast<uint32_t>(value + kSize / 4)));
+        ASSERT_FALSE(replay_32.canProceed(
+                static_cast<uint32_t>(value + kSize / 4)));
     }
 }

--- a/test_replay_protection.cpp
+++ b/test_replay_protection.cpp
@@ -1,0 +1,141 @@
+#include <gtest/gtest.h>
+
+#include "srtc/replay_protection.h"
+
+namespace {
+    constexpr uint32_t kSize = 2048;
+}
+
+TEST(HelloTest, BasicAssertions) {
+    EXPECT_STRNE("hello", "world");
+    EXPECT_EQ(7 * 6, 42);
+}
+
+// Replay protection
+
+TEST(ReplayProtection, TestEmpty) {
+
+    srtc::ReplayProtection replay_16(std::numeric_limits<uint16_t>::max(), kSize);
+    {
+        uint16_t value = 0;
+        while (true) {
+            ASSERT_TRUE(replay_16.canProceed(value));
+            uint16_t newValue = value + 100;
+            if (newValue < value) {
+                break;
+            }
+            value = newValue;
+        }
+    }
+
+    srtc::ReplayProtection replay_32(std::numeric_limits<uint32_t>::max(), kSize);
+    {
+        uint32_t value = 0;
+        while (true) {
+            ASSERT_TRUE(replay_32.canProceed(value));
+            uint32_t newValue = value + 100;
+            if (newValue < value || newValue >= std::numeric_limits<uint16_t>::max() * 10) {
+                break;
+            }
+            value = newValue;
+        }
+    }
+}
+
+TEST(ReplayProtection, TestSimple1)
+{
+    srtc::ReplayProtection replay_16(std::numeric_limits<uint16_t>::max(), kSize);
+    {
+        uint16_t value = 10328;
+        for (uint16_t i = 0; i < 20000; i += 1) {
+            ASSERT_TRUE(replay_16.canProceed(value));
+            ASSERT_TRUE(replay_16.set(value));
+            ASSERT_FALSE(replay_16.canProceed(value));
+            value += 1;
+        }
+    }
+}
+
+TEST(ReplayProtection, TestSimple2)
+{
+    srtc::ReplayProtection replay_16(std::numeric_limits<uint16_t>::max(), kSize);
+    {
+        uint16_t value = 12926;
+        for (uint16_t i = 0; i < 20000; i += 1) {
+            if (i >= 1) {
+                ASSERT_TRUE(replay_16.canProceed(value - 1));
+            }
+            if (i >= 2) {
+                ASSERT_FALSE(replay_16.canProceed(value - 2));
+            }
+            ASSERT_TRUE(replay_16.canProceed(value));
+            ASSERT_TRUE(replay_16.set(value));
+            ASSERT_FALSE(replay_16.canProceed(value));
+            value += 2;
+        }
+    }
+}
+
+TEST(ReplayProtection, TestSimpleWithRollover)
+{
+    srtc::ReplayProtection replay_16(std::numeric_limits<uint16_t>::max(), kSize);
+    {
+        uint16_t value = 42926;
+        for (uint16_t i = 0; ; i += 1) {
+            if (i >= 1) {
+                ASSERT_TRUE(replay_16.canProceed(
+                        static_cast<uint16_t>(value - 1))) << "-1, value = " << value;
+            }
+            if (i >= 2) {
+                ASSERT_FALSE(replay_16.canProceed(
+                        static_cast<uint16_t>(value - 100))) << "-100, value = " << value;
+            }
+            ASSERT_TRUE(replay_16.canProceed(value));
+            ASSERT_TRUE(replay_16.set(value));
+            ASSERT_FALSE(replay_16.canProceed(value));
+            value += 100;
+            if (value >= 30000 && value < 40000) {
+                break;
+            }
+        }
+    }
+}
+
+TEST(ReplayProtection, TestTooMuchForwardSimple)
+{
+    srtc::ReplayProtection replay_16(std::numeric_limits<uint16_t>::max(), kSize);
+    {
+        uint16_t value = 42926;
+        replay_16.set(value);
+
+        ASSERT_FALSE(replay_16.canProceed(value + kSize / 2));
+        ASSERT_FALSE(replay_16.canProceed(value - kSize));
+
+        ASSERT_TRUE(replay_16.canProceed(value + kSize / 4));
+        ASSERT_TRUE(replay_16.canProceed(value - kSize + 1));
+    }
+}
+
+TEST(ReplayProtection, TestTooMuchForwardSimpleWithRollover)
+{
+    srtc::ReplayProtection replay_16(std::numeric_limits<uint16_t>::max(), kSize);
+    {
+        uint16_t value = 65500;
+        replay_16.set(value);
+
+        ASSERT_FALSE(replay_16.canProceed(
+                static_cast<uint16_t>(value + kSize / 2)));
+        ASSERT_FALSE(replay_16.canProceed(
+                static_cast<uint16_t>(value - kSize)));
+
+        ASSERT_TRUE(replay_16.canProceed(
+                static_cast<uint16_t>(value + kSize / 4)));
+        ASSERT_TRUE(replay_16.canProceed(
+                static_cast<uint16_t>(value - kSize + 1)));
+
+        ASSERT_TRUE(replay_16.set(
+                static_cast<uint16_t>(value + kSize / 4)));
+        ASSERT_FALSE(replay_16.canProceed(
+                static_cast<uint16_t>(value + kSize / 4)));
+    }
+}


### PR DESCRIPTION
Implement a replay protection utility class.

This is the first step towards replacing Cisco's SRTP library with our own code, as receiving encrypted RTCP needs replay protection.
