### PR TITLE
SRTP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(srtc
         include/srtc/srtc.h
         include/srtc/srtp_connection.h
         include/srtc/srtp_crypto.h
+        include/srtc/srtp_hmac_sha1.h
         include/srtc/srtp_openssl.h
         include/srtc/srtp_util.h
         include/srtc/track.h
@@ -68,6 +69,7 @@ add_library(srtc
         srtc.cpp
         srtp_connection.cpp
         srtp_crypto.cpp
+        srtp_hmac_sha1.cpp
         srtp_openssl.cpp
         srtp_util.cpp
         track.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(srtc
         peer_connection.cpp
         random_generator.cpp
         replay_protection.cpp
+        replay_protection.cpp
         rtp_packet.cpp
         rtp_packet_source.cpp
         sdp_answer.cpp
@@ -83,7 +84,6 @@ target_link_libraries(
         srtc
         PRIVATE
         stun
-        srtp3
 )
 
 # Android specific
@@ -115,46 +115,6 @@ target_link_libraries(srtc
         OpenSSL::SSL
 )
 
-# LibSRTP
-
-list(APPEND LIBSRTP_CMAKE_ARGS
-        "-DLIBSRTP_TEST_APPS=OFF"
-        "-DENABLE_OPENSSL=ON"
-        "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
-)
-
-if(ANDROID)
-    list(APPEND LIBSRTP_CMAKE_ARGS
-        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
-        -DANDROID_ABI=${ANDROID_ABI}
-        -DANDROID_PLATFORM=android-29
-        -DCMAKE_FIND_ROOT_PATH=${OPENSSL_ROOT_DIR}
-    )
-endif()
-
-ExternalProject_Add(
-        srtp
-        GIT_REPOSITORY "https://github.com/cisco/libsrtp.git"
-        GIT_TAG "76f23aa78124381a9681b7b1a14c52c6cd40ea21"
-        SOURCE_DIR "external/libsrtp"
-        INSTALL_COMMAND ""
-        UPDATE_DISCONNECTED ON
-        CMAKE_ARGS ${LIBSRTP_CMAKE_ARGS}
-)
-
-set(SRTP_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/libsrtp/include")
-set(SRTP_LIBRARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/srtp-prefix/src/srtp-build")
-
-add_dependencies(srtc srtp)
-
-target_include_directories(srtc
-        PRIVATE
-        "${SRTP_INCLUDE_DIR}")
-
-target_link_directories(srtc
-        PUBLIC
-        "${SRTP_LIBRARY_DIR}")
-
 # STUN
 
 add_subdirectory(stun)
@@ -176,6 +136,36 @@ FetchContent_Declare(
 
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
+
+# LibSRTP - only for tests
+
+list(APPEND LIBSRTP_CMAKE_ARGS
+        "-DLIBSRTP_TEST_APPS=OFF"
+        "-DENABLE_OPENSSL=ON"
+        "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+        )
+
+if(ANDROID)
+    list(APPEND LIBSRTP_CMAKE_ARGS
+            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+            -DANDROID_ABI=${ANDROID_ABI}
+            -DANDROID_PLATFORM=android-29
+            -DCMAKE_FIND_ROOT_PATH=${OPENSSL_ROOT_DIR}
+            )
+endif()
+
+ExternalProject_Add(
+        srtp
+        GIT_REPOSITORY "https://github.com/cisco/libsrtp.git"
+        GIT_TAG "76f23aa78124381a9681b7b1a14c52c6cd40ea21"
+        SOURCE_DIR "external/libsrtp"
+        INSTALL_COMMAND ""
+        UPDATE_DISCONNECTED ON
+        CMAKE_ARGS ${LIBSRTP_CMAKE_ARGS}
+)
+
+set(SRTP_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/libsrtp/include")
+set(SRTP_LIBRARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/srtp-prefix/src/srtp-build")
 
 # Test executable
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is srtc, a simple WebRTC library (publish side only so far).
 
 Features:
 
-- Depends on OpenSSL (or BoringSSL) and [Cisco's libSRTP](https://github.com/cisco/libsrtp), nothing else.
+- Depends on OpenSSL (or BoringSSL) only, nothing else.
 - Portable code in "conservative" C++
 - Conservative means it uses C++ 17, can be made C++ 14 with little effort; does not use exceptions or RTTI.
 - Only one worker thread per PeerConnection.
@@ -67,8 +67,7 @@ This library, srtc, is my side project.
 
 ### Future plans
 
-First, I'd like to replace Cisco's SRTP library with my new code using OpenSSL / BoringSSL directly. This is currently
-in progress (incoming RTCP packets are decypted using our own code).
+First, I'd like to replace Cisco's SRTP library with my new code using OpenSSL / BoringSSL directly. This is done.
 
 Second, I'd lke to implement support for Simulcast (multiple video qualities on the same peer connection). There is a
 problem with this though - since I work for IVS, I know how IVS handles Simulcast but this information is not public,

--- a/include/srtc/rtp_packet.h
+++ b/include/srtc/rtp_packet.h
@@ -18,6 +18,7 @@ public:
 
     RtpPacket(const std::shared_ptr<Track>& track,
               bool marker,
+              uint32_t rollover,
               uint16_t sequence,
               uint32_t timestamp,
               ByteBuffer&& payload);
@@ -29,14 +30,20 @@ public:
     [[nodiscard]] uint16_t getSequence() const;
     [[nodiscard]] uint32_t getSSRC() const;
 
-    [[nodiscard]] ByteBuffer generate() const;
-    [[nodiscard]] ByteBuffer generateRtx() const;
+    struct Output {
+        uint32_t rollover;
+        ByteBuffer buf;
+    };
+
+    [[nodiscard]] Output generate() const;
+    [[nodiscard]] Output generateRtx() const;
 
 private:
     const std::shared_ptr<Track> mTrack;
     const uint32_t mSSRC;
     const uint8_t mPayloadId;
     const bool mMarker;
+    const uint32_t mRollover;
     const uint16_t mSequence;
     const uint32_t mTimestamp;
     const ByteBuffer mPayload;

--- a/include/srtc/rtp_packet_source.h
+++ b/include/srtc/rtp_packet_source.h
@@ -14,11 +14,13 @@ public:
     [[nodiscard]] uint32_t getSSRC() const;
     [[nodiscard]] uint8_t getPayloadId() const;
 
-    [[nodiscard]] uint16_t getNextSequence();
+    [[nodiscard]] std::pair<uint32_t, uint16_t> getNextSequence();
 
 private:
     const uint32_t mSSRC;
     const uint8_t mPayloadId;
+    uint32_t mGeneratedCount;
+    uint32_t mRollover;
     uint16_t mNextSequence;
 };
 

--- a/include/srtc/srtp_crypto.h
+++ b/include/srtc/srtp_crypto.h
@@ -11,6 +11,7 @@ struct evp_cipher_st;
 namespace srtc {
 
 class ByteBuffer;
+class HmacSha1;
 
 class SrtpCrypto {
 public:
@@ -22,6 +23,10 @@ public:
             const CryptoBytes& receiveMasterSalt);
 
     ~SrtpCrypto();
+
+    [[nodiscard]] bool protectSendRtp(const ByteBuffer& packet,
+                                      uint32_t rolloverCount,
+                                      ByteBuffer& encrypted);
 
     [[nodiscard]] bool unprotectReceiveRtcp(const ByteBuffer& packet,
                                             ByteBuffer& plain);
@@ -40,6 +45,10 @@ public:
                const CryptoVectors& receiveRtcp);
 
 private:
+    [[nodiscard]] bool protectSendRtpCM(const ByteBuffer& packet,
+                                        uint32_t rolloverCount,
+                                        ByteBuffer& encrypted);
+
     void computeReceiveRtcpIV(CryptoBytes& iv,
                               uint32_t ssrc,
                               uint32_t seq);
@@ -56,6 +65,8 @@ private:
 
     struct evp_cipher_ctx_st* mSendCipherCtx;
     struct evp_cipher_ctx_st* mReceiveCipherCtx;
+
+    std::shared_ptr<HmacSha1> mHmacSha1;
 };
 
 }

--- a/include/srtc/srtp_crypto.h
+++ b/include/srtc/srtp_crypto.h
@@ -6,6 +6,7 @@
 #include "srtc/srtp_util.h"
 
 struct evp_cipher_ctx_st;
+struct evp_cipher_st;
 
 namespace srtc {
 
@@ -15,6 +16,8 @@ class SrtpCrypto {
 public:
     [[nodiscard]] static std::pair<std::shared_ptr<SrtpCrypto>, Error> create(
             uint16_t profileId,
+            const CryptoBytes& sendMasterKey,
+            const CryptoBytes& sendMasterSalt,
             const CryptoBytes& receiveMasterKey,
             const CryptoBytes& receiveMasterSalt);
 
@@ -24,10 +27,17 @@ public:
                                             ByteBuffer& plain);
 
     // Implementation
+    struct CryptoVectors {
+        CryptoBytes key;
+        CryptoBytes auth;
+        CryptoBytes salt;
+    };
+
     SrtpCrypto(uint16_t profileId,
-               const CryptoBytes& receiveRtcpKey,
-               const CryptoBytes& receiveRtcpAuth,
-               const CryptoBytes& receiveRtcpSalt);
+               // Send RTP
+               const CryptoVectors& sendRtp,
+               // Receive RTCP
+               const CryptoVectors& receiveRtcp);
 
 private:
     void computeReceiveRtcpIV(CryptoBytes& iv,
@@ -38,9 +48,13 @@ private:
     [[nodiscard]] bool unprotectReceiveRtcpCM(const ByteBuffer& packet,
                                               ByteBuffer& plain);
 
-    const uint16_t mProfileId;
-    const CryptoBytes mReceiveRtcpKey, mReceiveRtcpAuth, mReceiveRtcpSalt;
+    [[nodiscard]] const struct evp_cipher_st* createCipher() const;
 
+    const uint16_t mProfileId;
+    const CryptoVectors mSendRtp;
+    const CryptoVectors mReceiveRtcp;
+
+    struct evp_cipher_ctx_st* mSendCipherCtx;
     struct evp_cipher_ctx_st* mReceiveCipherCtx;
 };
 

--- a/include/srtc/srtp_crypto.h
+++ b/include/srtc/srtp_crypto.h
@@ -49,9 +49,6 @@ private:
                                         uint32_t rolloverCount,
                                         ByteBuffer& encrypted);
 
-    void computeReceiveRtcpIV(CryptoBytes& iv,
-                              uint32_t ssrc,
-                              uint32_t seq);
     [[nodiscard]] bool unprotectReceiveRtcpGCM(const ByteBuffer& packet,
                                                ByteBuffer& plain);
     [[nodiscard]] bool unprotectReceiveRtcpCM(const ByteBuffer& packet,

--- a/include/srtc/srtp_crypto.h
+++ b/include/srtc/srtp_crypto.h
@@ -45,6 +45,9 @@ public:
                const CryptoVectors& receiveRtcp);
 
 private:
+    [[nodiscard]] bool protectSendRtpGCM(const ByteBuffer& packet,
+                                         uint32_t rolloverCount,
+                                         ByteBuffer& encrypted);
     [[nodiscard]] bool protectSendRtpCM(const ByteBuffer& packet,
                                         uint32_t rolloverCount,
                                         ByteBuffer& encrypted);

--- a/include/srtc/srtp_crypto.h
+++ b/include/srtc/srtp_crypto.h
@@ -24,8 +24,8 @@ public:
 
     ~SrtpCrypto();
 
-    [[nodiscard]] bool protectSendRtp(const ByteBuffer& packet,
-                                      uint32_t rolloverCount,
+    [[nodiscard]] bool protectSendRtp(uint32_t rolloverCount,
+                                      const ByteBuffer& packet,
                                       ByteBuffer& encrypted);
 
     [[nodiscard]] bool unprotectReceiveRtcp(const ByteBuffer& packet,
@@ -45,11 +45,11 @@ public:
                const CryptoVectors& receiveRtcp);
 
 private:
-    [[nodiscard]] bool protectSendRtpGCM(const ByteBuffer& packet,
-                                         uint32_t rolloverCount,
+    [[nodiscard]] bool protectSendRtpGCM(uint32_t rolloverCount,
+                                         const ByteBuffer& packet,
                                          ByteBuffer& encrypted);
-    [[nodiscard]] bool protectSendRtpCM(const ByteBuffer& packet,
-                                        uint32_t rolloverCount,
+    [[nodiscard]] bool protectSendRtpCM(uint32_t rolloverCount,
+                                        const ByteBuffer& packet,
                                         ByteBuffer& encrypted);
 
     [[nodiscard]] bool unprotectReceiveRtcpGCM(const ByteBuffer& packet,

--- a/include/srtc/srtp_hmac_sha1.h
+++ b/include/srtc/srtp_hmac_sha1.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+#include <openssl/hmac.h>
+
+namespace srtc {
+
+class HmacSha1 {
+public:
+    HmacSha1();
+    ~HmacSha1();
+
+    [[nodiscard]] bool reset(const uint8_t* key,
+                             size_t keySize);
+    void update(const uint8_t* data,
+                size_t size);
+    void final(uint8_t* out);
+
+private:
+    HMAC_CTX* mCtx;
+};
+
+}

--- a/include/srtc/srtp_util.h
+++ b/include/srtc/srtp_util.h
@@ -5,7 +5,7 @@
 
 namespace srtc {
 
-class CryptoBytesWriter;
+class CryptoWriter;
 
 // ----- CryptoBytes
 
@@ -28,16 +28,16 @@ public:
     CryptoBytes& operator^=(const CryptoBytes& other);
 
 private:
-    friend CryptoBytesWriter;
+    friend CryptoWriter;
 
     size_t mSize;
 };
 
-// ----- CryptoBytesWriter
+// ----- CryptoWriter
 
-class CryptoBytesWriter {
+class CryptoWriter {
 public:
-    explicit CryptoBytesWriter(CryptoBytes& bytes);
+    explicit CryptoWriter(CryptoBytes& bytes);
 
     void writeU8(uint8_t value);
     void writeU16(uint16_t value);
@@ -54,6 +54,7 @@ private:
 class KeyDerivation {
 public:
     static constexpr uint8_t kLabelRtpKey = 0;
+    static constexpr uint8_t kLabelRtpAuth = 1;
     static constexpr uint8_t kLabelRtpSalt = 2;
     static constexpr uint8_t kLabelRtcpKey = 3;
     static constexpr uint8_t kLabelRtcpAuth = 4;

--- a/packetizer_opus.cpp
+++ b/packetizer_opus.cpp
@@ -23,9 +23,10 @@ std::list<std::shared_ptr<RtpPacket>> PacketizerOpus::generate(const std::shared
         payload.resize(RtpPacket::kMaxPayloadSize);
     }
 
+    const auto [rollover, sequence] = packetSource->getNextSequence();
     result.push_back(
             std::make_shared<RtpPacket>(
-                    track, false, packetSource->getNextSequence(), frameTimestamp, std::move(payload)));
+                    track, false, rollover, sequence, frameTimestamp, std::move(payload)));
 
     return result;
 }

--- a/rtp_packet_source.cpp
+++ b/rtp_packet_source.cpp
@@ -9,7 +9,9 @@ RtpPacketSource::RtpPacketSource(uint32_t ssrc,
                                  uint8_t payloadId)
     : mSSRC(ssrc)
     , mPayloadId(payloadId)
-    , mNextSequence(static_cast<uint16_t>(lrand48()))
+    , mGeneratedCount(0)
+    , mRollover(0)
+    , mNextSequence(10000 + static_cast<uint16_t>(lrand48() % 20000))
 {
 }
 
@@ -24,9 +26,16 @@ uint8_t RtpPacketSource::getPayloadId() const
     return mPayloadId;
 }
 
-uint16_t RtpPacketSource::getNextSequence()
+std::pair<uint32_t, uint16_t> RtpPacketSource::getNextSequence()
 {
-    return mNextSequence++;
+    mGeneratedCount += 1;
+    mNextSequence += 1;
+
+    if (mGeneratedCount > 1 && mNextSequence == 0) {
+        mRollover += 1;
+    }
+
+    return { mRollover, mNextSequence };
 }
 
 }

--- a/srtp_crypto.cpp
+++ b/srtp_crypto.cpp
@@ -105,8 +105,8 @@ std::pair<std::shared_ptr<SrtpCrypto>, Error> SrtpCrypto::create(
     };
 }
 
-bool SrtpCrypto::protectSendRtp(const ByteBuffer& packet,
-                                uint32_t rolloverCount,
+bool SrtpCrypto::protectSendRtp(uint32_t rolloverCount,
+                                const ByteBuffer& packet,
                                 ByteBuffer& encrypted)
 {
     encrypted.resize(0);
@@ -114,18 +114,18 @@ bool SrtpCrypto::protectSendRtp(const ByteBuffer& packet,
     switch (mProfileId) {
         case SRTP_AEAD_AES_256_GCM:
         case SRTP_AEAD_AES_128_GCM:
-            return protectSendRtpGCM(packet, rolloverCount, encrypted);
+            return protectSendRtpGCM(rolloverCount, packet, encrypted);
         case SRTP_AES128_CM_SHA1_80:
         case SRTP_AES128_CM_SHA1_32:
-            return protectSendRtpCM(packet, rolloverCount, encrypted);
+            return protectSendRtpCM(rolloverCount, packet, encrypted);
         default:
             assert(false);
             return false;
     }
 }
 
-bool SrtpCrypto::protectSendRtpGCM(const ByteBuffer& packet,
-                                   uint32_t rolloverCount,
+bool SrtpCrypto::protectSendRtpGCM(uint32_t rolloverCount,
+                                   const ByteBuffer& packet,
                                    ByteBuffer& encrypted)
 {
     const auto ctx = mSendCipherCtx;
@@ -205,8 +205,8 @@ fail:
     return false;
 }
 
-bool SrtpCrypto::protectSendRtpCM(const ByteBuffer& packet,
-                                  uint32_t rolloverCount,
+bool SrtpCrypto::protectSendRtpCM(uint32_t rolloverCount,
+                                  const ByteBuffer& packet,
                                   ByteBuffer& encrypted)
 {
     const auto ctx = mSendCipherCtx;

--- a/srtp_hmac_sha1.cpp
+++ b/srtp_hmac_sha1.cpp
@@ -1,0 +1,57 @@
+// Some code in this file is based on Cisco's libSRTP
+// https://github.com/cisco/libsrtp
+// Copyright (c) 2001-2017 Cisco Systems, Inc.
+// All rights reserved.
+// Neither the name of the Cisco Systems, Inc. nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+
+#include "srtc/srtp_hmac_sha1.h"
+
+#include <cassert>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+namespace srtc {
+
+HmacSha1::HmacSha1()
+    : mCtx(HMAC_CTX_new())
+{
+}
+
+HmacSha1::~HmacSha1()
+{
+    if (mCtx) {
+        HMAC_CTX_free(mCtx);
+    }
+}
+
+bool HmacSha1::reset(const uint8_t* key,
+                     size_t keySize)
+{
+    if (!mCtx) {
+        return false;
+    }
+
+    HMAC_Init_ex(mCtx, key, static_cast<int>(keySize), EVP_sha1(), nullptr);
+    return true;
+}
+
+void HmacSha1::update(const uint8_t* data,
+                      size_t size)
+{
+    HMAC_Update(mCtx, data, size);
+}
+
+void HmacSha1::final(uint8_t* out)
+{
+    unsigned int out_len;
+    HMAC_Final(mCtx, out, &out_len);
+
+    assert(out_len == 20);
+}
+
+}
+
+#pragma clang diagnostic pop

--- a/srtp_util.cpp
+++ b/srtp_util.cpp
@@ -70,15 +70,15 @@ CryptoBytes& CryptoBytes::operator^=(const CryptoBytes& other)
     return *this;
 }
 
-// ----- CryptoBytesWriter
+// ----- CryptoWriter
 
-CryptoBytesWriter::CryptoBytesWriter(CryptoBytes& bytes)
+CryptoWriter::CryptoWriter(CryptoBytes& bytes)
     : mBytes(bytes)
 {
     mBytes.clear();
 }
 
-void CryptoBytesWriter::writeU8(uint8_t value)
+void CryptoWriter::writeU8(uint8_t value)
 {
     assert(mBytes.mSize <= sizeof(mBytes.v8) - 1);
     if (mBytes.mSize <= sizeof(mBytes.v8) - 1) {
@@ -86,7 +86,7 @@ void CryptoBytesWriter::writeU8(uint8_t value)
     }
 }
 
-void CryptoBytesWriter::writeU16(uint16_t value)
+void CryptoWriter::writeU16(uint16_t value)
 {
     assert(mBytes.mSize <= sizeof(mBytes.v8) - 2);
     if (mBytes.mSize <= sizeof(mBytes.v8) - 2) {
@@ -95,7 +95,7 @@ void CryptoBytesWriter::writeU16(uint16_t value)
     }
 }
 
-void CryptoBytesWriter::writeU32(uint32_t value)
+void CryptoWriter::writeU32(uint32_t value)
 {
     assert(mBytes.mSize <= sizeof(mBytes.v8) - 4);
     if (mBytes.mSize <= sizeof(mBytes.v8) - 4) {
@@ -106,7 +106,7 @@ void CryptoBytesWriter::writeU32(uint32_t value)
     }
 }
 
-void CryptoBytesWriter::append(const uint8_t* data, size_t size)
+void CryptoWriter::append(const uint8_t* data, size_t size)
 {
     assert(mBytes.mSize <= sizeof(mBytes.v8) - size);
     if (mBytes.mSize <= sizeof(mBytes.v8) - size) {
@@ -144,7 +144,7 @@ bool KeyDerivation::generate(const CryptoBytes& masterKey,
     const auto blockCount = (desiredOutputSize + 15) / 16;
     bool res = false;
 
-    srtc::CryptoBytesWriter outputWriter(output);
+    srtc::CryptoWriter outputWriter(output);
 
     const auto ctx = EVP_CIPHER_CTX_new();
     if (!ctx) {

--- a/test_srtp_crypto.cpp
+++ b/test_srtp_crypto.cpp
@@ -276,7 +276,7 @@ TEST(SrtpCrypto, RtpSend)
         // Randomly generate RTCP packets, encrypt them using libSRTP and our crypto.
         // Verify that the result of encryption is the same for both.
         uint32_t ssrc = 0x12345678;
-        uint16_t sequence = 65000;
+        uint16_t sequence = 61000;
         uint32_t rolloverCount = 0;
         uint32_t timestamp = 10000;
 

--- a/test_srtp_crypto.cpp
+++ b/test_srtp_crypto.cpp
@@ -187,8 +187,8 @@ TEST(SrtpCrypto, RtpSend)
     srtc::initOpenSSL();
 
     static const uint16_t kOpenSslProfileList[] = {
-//            SRTP_AEAD_AES_256_GCM,
-//            SRTP_AEAD_AES_128_GCM,
+            SRTP_AEAD_AES_256_GCM,
+            SRTP_AEAD_AES_128_GCM,
             SRTP_AES128_CM_SHA1_80,
             SRTP_AES128_CM_SHA1_32
     };
@@ -276,7 +276,7 @@ TEST(SrtpCrypto, RtpSend)
         // Randomly generate RTCP packets, encrypt them using libSRTP and our crypto.
         // Verify that the result of encryption is the same for both.
         uint32_t ssrc = 0x12345678;
-        uint16_t sequence = 61000;
+        uint16_t sequence = 65000;
         uint32_t rolloverCount = 0;
         uint32_t timestamp = 10000;
 

--- a/test_srtp_crypto.cpp
+++ b/test_srtp_crypto.cpp
@@ -4,6 +4,8 @@
 #include "srtc/byte_buffer.h"
 #include "srtc/srtp_crypto.h"
 #include "srtc/srtp_openssl.h"
+#include "srtc/track.h"
+#include "srtc/rtp_packet.h"
 
 #include <mutex>
 #include <cstring>
@@ -172,5 +174,159 @@ TEST(SrtpCrypto, RtcpReceive)
 
         // Cleanup
         srtp_dealloc(srtp);
+    }
+}
+
+// RTP send
+
+TEST(SrtpCrypto, RtpSend)
+{
+    std::cout << "SrtpCrypto RtpSend" << std::endl;
+
+    initLibSRTP();
+    srtc::initOpenSSL();
+
+    static const uint16_t kOpenSslProfileList[] = {
+//            SRTP_AEAD_AES_256_GCM,
+//            SRTP_AEAD_AES_128_GCM,
+            SRTP_AES128_CM_SHA1_80,
+            SRTP_AES128_CM_SHA1_32
+    };
+
+    for (const auto openSSlProfile: kOpenSslProfileList) {
+        const char *srtpProfileName;
+        srtp_profile_t srtpProfileId;
+        size_t srtpKeySize = {0}, srtpSaltSize = {0};
+
+        switch (openSSlProfile) {
+            case SRTP_AEAD_AES_256_GCM:
+                srtpProfileName = "SRTP_AEAD_AES_256_GCM";
+                srtpProfileId = srtp_profile_aead_aes_256_gcm;
+                srtpKeySize = SRTP_AES_256_KEY_LEN;
+                srtpSaltSize = SRTP_AEAD_SALT_LEN;
+                break;
+            case SRTP_AEAD_AES_128_GCM:
+                srtpProfileName = "SRTP_AEAD_AES_128_GCM";
+                srtpProfileId = srtp_profile_aead_aes_128_gcm;
+                srtpKeySize = SRTP_AES_128_KEY_LEN;
+                srtpSaltSize = SRTP_AEAD_SALT_LEN;
+                break;
+            case SRTP_AES128_CM_SHA1_80:
+                srtpProfileName = "SRTP_AES128_CM_SHA1_80";
+                srtpProfileId = srtp_profile_aes128_cm_sha1_80;
+                srtpKeySize = SRTP_AES_128_KEY_LEN;
+                srtpSaltSize = SRTP_SALT_LEN;
+                break;
+            case SRTP_AES128_CM_SHA1_32:
+                srtpProfileName = "SRTP_AES128_CM_SHA1_32";
+                srtpProfileId = srtp_profile_aes128_cm_sha1_32;
+                srtpKeySize = SRTP_AES_128_KEY_LEN;
+                srtpSaltSize = SRTP_SALT_LEN;
+                break;
+            default:
+                ASSERT_TRUE(false);
+                break;
+        }
+
+        std::cout << "Testing " << srtpProfileName << std::endl;
+
+        // Generate random keys and salts
+        uint8_t bufSendMasterKey[32], bufSendMasterSalt[32];
+        RAND_bytes(bufSendMasterKey, sizeof(bufSendMasterKey));
+        RAND_bytes(bufSendMasterKey, sizeof(bufSendMasterKey));
+
+        uint8_t bufReceiveMasterKey[32], bufReceiveMasterSalt[32];
+        RAND_bytes(bufReceiveMasterKey, sizeof(bufReceiveMasterKey));
+        RAND_bytes(bufReceiveMasterSalt, sizeof(bufReceiveMasterSalt));
+
+        // Convert to our objects
+        srtc::CryptoBytes sendMasterKey, sendMasterSalt;
+        sendMasterKey.assign(bufSendMasterKey, srtpKeySize);
+        sendMasterSalt.assign(bufSendMasterSalt, srtpSaltSize);
+
+        srtc::CryptoBytes receiveMasterKey, receiveMasterSalt;
+        receiveMasterKey.assign(bufReceiveMasterKey, srtpKeySize);
+        receiveMasterSalt.assign(bufReceiveMasterSalt, srtpSaltSize);
+
+        // Create our own crypto
+        const auto [crypto, error] = srtc::SrtpCrypto::create(openSSlProfile,
+                                                              sendMasterKey, sendMasterSalt,
+                                                              receiveMasterKey, receiveMasterSalt);
+        ASSERT_TRUE(error.isOk());
+        ASSERT_TRUE(crypto);
+
+        // Create libSRTP crypto
+        srtc::ByteBuffer bufMasterCombined;
+        bufMasterCombined.append(bufSendMasterKey, srtpKeySize);
+        bufMasterCombined.append(bufSendMasterSalt, srtpSaltSize);
+
+        srtp_policy_t srtpPolicy;
+
+        std::memset(&srtpPolicy, 0, sizeof(srtpPolicy));
+        srtpPolicy.ssrc.type = ssrc_any_outbound;
+        srtpPolicy.key = bufMasterCombined.data();
+        srtpPolicy.allow_repeat_tx = true;
+
+        srtp_crypto_policy_set_from_profile_for_rtp(&srtpPolicy.rtp, srtpProfileId);
+        srtp_crypto_policy_set_from_profile_for_rtcp(&srtpPolicy.rtcp, srtpProfileId);
+
+        srtp_t srtp = nullptr;
+        ASSERT_EQ(srtp_create(&srtp, &srtpPolicy), srtp_err_status_ok);
+
+        // Randomly generate RTCP packets, encrypt them using libSRTP and our crypto.
+        // Verify that the result of encryption is the same for both.
+        uint32_t ssrc = 0x12345678;
+        uint16_t sequence = 65000;
+        uint32_t rolloverCount = 0;
+        uint32_t timestamp = 10000;
+
+        std::optional<uint16_t> prevSequence;
+
+        const auto track = std::make_shared<srtc::Track>(0, srtc::MediaType::Video,
+                                                         ssrc, 96,
+                                                         0, 0,
+                                                         srtc::Codec::H264,
+                                                         false, false);
+
+        for (auto repeatIndex = 0; repeatIndex < 1000; repeatIndex += 1) {
+            const auto payloadSize = 5 + lrand48() % 1000;
+            srtc::ByteBuffer payload(payloadSize);
+            RAND_bytes(payload.data(), static_cast<int>(payload.capacity()));
+            payload.resize(payloadSize);
+
+            const auto packet = std::make_shared<srtc::RtpPacket>(track, false, sequence, timestamp,
+                                                                  std::move(payload));
+            // This is our packet's unencrypted data
+            const auto source = packet->generate();
+
+            // Encrypt using libSRTP
+            srtc::ByteBuffer protectedLibSrtp(source.size() + SRTP_MAX_TRAILER_LEN);
+            size_t protectedSize = protectedLibSrtp.capacity();
+            ASSERT_EQ(srtp_protect(srtp, source.data(), source.size(),
+                         protectedLibSrtp.data(), &protectedSize, 0), srtp_err_status_ok);
+            protectedLibSrtp.resize(protectedSize);
+
+            // Rollover counter
+            if (prevSequence.has_value() && prevSequence > sequence) {
+                rolloverCount += 1;
+            }
+            prevSequence = sequence;
+
+            // Encrypt using our own crypto
+            srtc::ByteBuffer protectedSrtcCrypto;
+            ASSERT_TRUE(crypto->protectSendRtp(source, rolloverCount, protectedSrtcCrypto));
+
+            // Validate
+            ASSERT_EQ(protectedLibSrtp.size(), protectedSrtcCrypto.size());
+
+            for (size_t i = 0; i < protectedSize; i += 1) {
+                ASSERT_EQ(protectedLibSrtp.data()[i], protectedSrtcCrypto.data()[i])
+                    << " diff at offset " << i << std::endl;
+            }
+
+            // Advance
+            sequence += 1;
+            timestamp += 1723;
+        }
     }
 }

--- a/test_srtp_key_derivation.cpp
+++ b/test_srtp_key_derivation.cpp
@@ -25,7 +25,7 @@ void initLibSRTP()
 
 void setFromHex(srtc::CryptoBytes& bytes, const char* hex)
 {
-    srtc::CryptoBytesWriter w(bytes);
+    srtc::CryptoWriter w(bytes);
 
     uint8_t value = 0;
     uint8_t count = 0;


### PR DESCRIPTION
Use our own code for encrypting ourgoing SRTP packets.

This removes the use of Cisco's libSRTP.
