### PR TITLE
Track refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ add_library(srtc
         include/srtc/jitter_buffer_item.h
         include/srtc/jitter_buffer.h
         include/srtc/logging.h
+        include/srtc/media.h
         include/srtc/packetizer.h
         include/srtc/packetizer_av1.h
         include/srtc/packetizer_h264.h
@@ -134,6 +135,7 @@ add_library(srtc
         src/ice_agent.cpp
         src/jitter_buffer.cpp
         src/logging.cpp
+        src/media.cpp
         src/packetizer.cpp
         src/packetizer_av1.cpp
         src/packetizer_h264.cpp

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ This is srtc, a "simple" WebRTC library (publish side is done and working quite 
 - Audo codec: Opus.
 - SDP offer generation and SDP response parsing.
 - ICE / STUN negotiation, DTLS negotiation, SRTP and SRTCP.
+- IPv4 and IPv6.
 - Data channels (both sending and receiving).
-- Support for IPv4 and IPv6.
+- Multiple data streams (SDP "media lines")
 - Tested with Pion and Amazon IVS (Interactive Video Service)
 - Works on Linux, Android, MacOS, Windows, and should work on iOS too.
 
@@ -39,9 +40,9 @@ Efficient. Can be used for publishing media from a server side system i.e. where
 perhaps thousands) of simultaneous WebRTC sessions on a single computer so Google's implementation is not a good choice
 due to its hunger for threads.
 
-Has a command line tool to publish video, [which has already seen some use](https://www.linkedin.com/posts/toddrsharp_releases-kmansoftsrtc-activity-7342987919445385216-N74_?utm_source=share&utm_medium=member_desktop&rcm=ACoAADsOqaEBZ5sFObLsqWe6Ii4d-zOg-Q6-iVM).
+Has a command line tool / sample code to publish video, [which has already seen some use](https://www.linkedin.com/posts/toddrsharp_releases-kmansoftsrtc-activity-7342987919445385216-N74_?utm_source=share&utm_medium=member_desktop&rcm=ACoAADsOqaEBZ5sFObLsqWe6Ii4d-zOg-Q6-iVM).
 
-Has a command line tool to subscribe to audio and/or video, which can save media to files.
+Has a command line tool / sample code to subscribe to audio and/or video, which can save media to files.
 
 Media encoding / decoding and presentation are deliberately out of scope of this library. For publishing, the application needs to
 provide encoded media samples. For subscribing, the application receives encoded media samples which it needs to decode and present.
@@ -61,15 +62,20 @@ state callback.
 
 Once the peer is connected, you can start publishing audio and video samples using these methods:
 
-- setVideoSingleCodecSpecificData
-- publishVideoSingleFrame
+- setVideoCodecSpecificData
+- publishVideoFrame
 - publishAudioFrame
 
-For simulcast, the methods are similar but different:
+You will need to provide a `Track` for the above methods. The list of negotiated tracks can be obtained from the SDP
+answer after parsing.
+
+For simulcast, the flow is:
 
 - Configure your layers when generating the offer
-- setVideoSimulcastCodecSpecificData
-- publishVideoSimulcastFrame
+- setVideoCodecSpecificData
+- publishVideoFrame
+
+The SDP answer will have a `Track` per layer you requested. Use one of these tracks to address the layer. 
 
 For subscribing, use the `setSubscribeEncodedFrameListener` method to receive encoded frames as they come out of the jitter buffer.
 

--- a/include/srtc/extension_map.h
+++ b/include/srtc/extension_map.h
@@ -10,8 +10,8 @@ namespace srtc
 class ExtensionMap
 {
 public:
-    ExtensionMap() = default;
-    ~ExtensionMap() = default;
+    ExtensionMap();
+    ~ExtensionMap();
 
     void add(uint8_t id, const std::string& name);
 
@@ -31,6 +31,9 @@ private:
     };
 
     std::vector<Entry> mEntryList;
+
+    mutable std::string mLastName;
+    mutable uint8_t mLastId;
 };
 
 } // namespace srtc

--- a/include/srtc/extension_map.h
+++ b/include/srtc/extension_map.h
@@ -18,6 +18,8 @@ public:
     [[nodiscard]] uint8_t findByName(const std::string& name) const;
     [[nodiscard]] std::string findById(uint8_t id) const;
 
+    void clear();
+
 private:
     struct Entry {
         Entry(uint8_t id, const std::string& name)

--- a/include/srtc/media.h
+++ b/include/srtc/media.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "srtc/srtc.h"
+
+#include <string>
+
+namespace srtc
+{
+
+class Media
+{
+public:
+    Media(const std::string& id, MediaType type);
+    ~Media();
+
+    [[nodiscard]] std::string getId() const;
+    [[nodiscard]] MediaType getType() const;
+
+private:
+    const std::string mId;
+    const MediaType mType;
+};
+
+} // namespace srtc

--- a/include/srtc/media.h
+++ b/include/srtc/media.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "srtc/srtc.h"
+#include "srtc/extension_map.h"
 
 #include <string>
 
@@ -11,14 +12,17 @@ class Media
 {
 public:
     Media(const std::string& id, MediaType type);
+    Media(const std::string& id, MediaType type, const ExtensionMap& extensionMap);
     ~Media();
 
     [[nodiscard]] std::string getId() const;
     [[nodiscard]] MediaType getType() const;
+    [[nodiscard]] const ExtensionMap& getExtensionMap() const;
 
 private:
     const std::string mId;
     const MediaType mType;
+    const ExtensionMap mExtensionMap;
 };
 
 } // namespace srtc

--- a/include/srtc/peer_candidate.h
+++ b/include/srtc/peer_candidate.h
@@ -136,10 +136,6 @@ private:
     const std::unique_ptr<uint8_t[]> mIceMessageBuffer;
     const std::shared_ptr<SendRtpHistory> mSendRtpHistory;
     const uint32_t mUniqueId;
-    const uint8_t mVideoExtMediaId;
-    const uint8_t mVideoExtStreamId;
-    const uint8_t mVideoExtRepairedStreamId;
-    const uint8_t mVideoExtGoogleVLA;
     const std::shared_ptr<RtpExtensionSourceSimulcast> mExtensionSourceSimulcast;
     const std::shared_ptr<RtpExtensionSourceTWCC> mExtensionSourceTWCC;
     const std::shared_ptr<RtpResponderTWCC> mResponderTWCC;

--- a/include/srtc/peer_candidate.h
+++ b/include/srtc/peer_candidate.h
@@ -78,9 +78,9 @@ public:
     [[nodiscard]] int getTimeoutMillis(int defaultValue) const;
     void run();
 
-    void sendSenderReports(const std::vector<std::shared_ptr<Track>>& trackList);
-    void sendReceiverReports(const std::vector<std::shared_ptr<Track>>& trackList);
-    void sendPictureLossIndicators(const std::vector<std::shared_ptr<Track>>& trackList);
+    void sendSenderReports();
+    void sendReceiverReports();
+    void sendPictureLossIndicators();
     void sendNacks(const std::shared_ptr<Track>& track, const std::vector<uint16_t>& nackList);
 
     void updatePublishConnectionStats(PublishConnectionStats& stats) const;
@@ -158,6 +158,8 @@ private:
     std::list<ByteBuffer> mRawSendQueue;
     std::list<FrameToSend> mFrameSendQueue;
     std::list<DataChannelMessage> mDataSendQueue;
+
+    std::vector<SimulcastLayer> mSimulcastLayerList;
 
     bool mSentUseCandidate;
     bool mIsConnected;

--- a/include/srtc/peer_candidate_listener.h
+++ b/include/srtc/peer_candidate_listener.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace srtc
 {
@@ -11,6 +11,7 @@ class ByteBuffer;
 class PeerCandidate;
 class Error;
 class RtpPacket;
+class Media;
 class Track;
 
 struct SenderReport;
@@ -36,7 +37,8 @@ public:
 
     virtual void onCandidateReceivedKeyFrameRequest(PeerCandidate* candiate) = 0;
 
-    [[nodiscard]] virtual const std::vector<SimulcastLayer>& getSimulcastLayerList() const = 0;
+    virtual void getSimulcastLayerList(const std::shared_ptr<Media>& media,
+                                       std::vector<SimulcastLayer>& layerList) const = 0;
 
     virtual void onSctpDataChannelOpen(const std::string& label) = 0;
     virtual void onSctpDataChannelText(const std::string& label, const std::string& data) = 0;

--- a/include/srtc/peer_connection.h
+++ b/include/srtc/peer_connection.h
@@ -39,12 +39,8 @@ public:
     // SDP offer
     using OfferAndError = std::pair<std::shared_ptr<SdpOffer>, Error>;
 
-    OfferAndError createPublishOffer(const PubOfferConfig& pubConfig,
-                                     const std::optional<PubVideoConfig>& videoConfig,
-                                     const std::optional<PubAudioConfig>& audioConfig);
-    OfferAndError createSubscribeOffer(const SubOfferConfig& subConfig,
-                                       const std::optional<SubVideoConfig>& videoConfig,
-                                       const std::optional<SubAudioConfig>& audioConfig);
+    OfferAndError createPublishOffer(const PubOfferConfig& pubConfig, const PubMediaConfig& mediaConfig);
+    OfferAndError createSubscribeOffer(const SubOfferConfig& subConfig, const SubMediaConfig& mediaConfig);
     Error setOffer(const std::shared_ptr<SdpOffer>& offer);
 
     // SDP answer
@@ -61,9 +57,8 @@ public:
     std::shared_ptr<SdpOffer> getOffer() const;
     std::shared_ptr<SdpAnswer> getAnswer() const;
 
-    std::shared_ptr<Track> getVideoSingleTrack() const;
-    std::vector<std::shared_ptr<Track>> getVideoSimulcastTrackList() const;
-    std::shared_ptr<Track> getAudioTrack() const;
+    std::vector<std::shared_ptr<Media>> getMediaList() const;
+    std::vector<std::shared_ptr<Track>> getTrackList() const;
 
     // Connection state listener
     enum class ConnectionState {
@@ -84,14 +79,10 @@ public:
     void setPublishKeyFrameRequestedListener(const PublishKeyFrameRequestedListener& listener);
 
     // Publishing media
-    Error setVideoSingleCodecSpecificData(std::vector<ByteBuffer>&& list);
-    Error publishVideoSingleFrame(int64_t pts_usec, ByteBuffer&& buf);
-
-    Error setVideoSimulcastCodecSpecificData(const std::string& layerName, std::vector<ByteBuffer>&& list);
-    Error publishVideoSimulcastFrame(int64_t pts_usec, const std::string& layerName, ByteBuffer&& buf);
-    Error updateVideoSimulcastLayer(const SimulcastLayer& layer);
-
-    Error publishAudioFrame(int64_t pts_usec, ByteBuffer&& buf);
+    Error setVideoCodecSpecificData(const std::shared_ptr<Track>& track, std::vector<ByteBuffer>&& list);
+    Error publishVideoFrame(const std::shared_ptr<Track>& track, int64_t pts_usec, ByteBuffer&& buf);
+    Error updateVideoSimulcastLayer(const std::shared_ptr<Track>& track, const SimulcastLayer& layer);
+    Error publishAudioFrame(const std::shared_ptr<Track>& track, int64_t pts_usec, ByteBuffer&& buf);
 
     // Subscribe listeners
     using SubscribeConnectionStatsListener = std::function<void(const SubscribeConnectionStats&)>;
@@ -109,8 +100,7 @@ public:
     [[nodiscard]] Error sendDataChannelText(const std::string& label, std::string&& data);
     [[nodiscard]] Error sendDataChannelBinary(const std::string& label, ByteBuffer&& data);
 
-    struct DataChannelListener
-    {
+    struct DataChannelListener {
         virtual ~DataChannelListener();
 
         virtual void onDataChannelOpened(const std::string& label) = 0;
@@ -133,26 +123,6 @@ private:
     std::shared_ptr<SdpAnswer> mSdpAnswer SRTC_GUARDED_BY(mMutex);
     bool mDataChannelsNegotiated = false;
     uint32_t mDataChannelMaxMessageSize = 0;
-
-    std::shared_ptr<Track> mVideoSingleTrack;
-    std::vector<std::shared_ptr<Track>> mVideoSimulcastTrackList;
-    std::shared_ptr<Track> mAudioTrack;
-
-    struct LayerInfo {
-        LayerInfo(const std::string& ridName,
-                  const std::shared_ptr<Track>& track,
-                  const std::shared_ptr<Packetizer>& packetizer)
-            : ridName(ridName)
-            , track(track)
-            , packetizer(packetizer)
-        {
-        }
-
-        std::string ridName;
-        std::shared_ptr<Track> track;
-        std::shared_ptr<Packetizer> packetizer;
-    };
-    std::vector<LayerInfo> mVideoSimulcastLayerList;
 
     void networkThreadWorkerFunc();
 
@@ -181,9 +151,6 @@ private:
     std::list<FrameToSend> mFrameSendQueue SRTC_GUARDED_BY(mMutex);
     std::list<DataChannelMessage> mDataSendQueue SRTC_GUARDED_BY(mMutex);
 
-    // Simulcast layer list
-    std::vector<SimulcastLayer> mSendSimulcastLayerList;
-
     // Jitter buffer processing
     void processJitterBuffer(const std::shared_ptr<JitterBuffer>& buffer);
 
@@ -199,7 +166,8 @@ private:
                                          const std::shared_ptr<Track>& track,
                                          const SenderReport& sr) override;
     void onCandidateReceivedKeyFrameRequest(PeerCandidate* candiate) override;
-    const std::vector<SimulcastLayer>& getSimulcastLayerList() const override;
+    void getSimulcastLayerList(const std::shared_ptr<Media>& media,
+                               std::vector<SimulcastLayer>& layerList) const override;
 
     void onSctpDataChannelOpen(const std::string& label) override;
     void onSctpDataChannelText(const std::string& label, const std::string& data) override;
@@ -218,17 +186,35 @@ private:
     SubscribeSenderReportListener mSubscribeSenderReportsListener SRTC_GUARDED_BY(mListenerMutex);
     std::shared_ptr<DataChannelListener> mDataChannelListener SRTC_GUARDED_BY(mListenerMutex);
 
-    // Packetizers
-    std::shared_ptr<Packetizer> mVideoSinglePacketizer;
-    std::shared_ptr<Packetizer> mAudioPacketizer;
+    // Media
+    struct MediaEntry {
+        const std::shared_ptr<Media> media;
+        std::vector<SimulcastLayer> layerList;
 
-    // Depacketizers
-    std::shared_ptr<Depacketizer> mVideoDepacketizer;
-    std::shared_ptr<Depacketizer> mAudioDepacketizer;
+        MediaEntry(const std::shared_ptr<Media>& media)
+            : media(media)
+        {
+        }
+    };
+    std::vector<MediaEntry> mMediaEntryList SRTC_GUARDED_BY(mMutex);
 
-    // Jitter buffers
-    std::shared_ptr<JitterBuffer> mJitterBufferVideo;
-    std::shared_ptr<JitterBuffer> mJitterBufferAudio;
+    // Tracks
+    struct TrackEntry {
+        const std::shared_ptr<Track> track;
+
+        // Publishing
+        std::shared_ptr<Packetizer> packetizer;
+
+        // Subscribing
+        std::shared_ptr<Depacketizer> depacketizer;
+        std::shared_ptr<JitterBuffer> jitterBuffer;
+
+        TrackEntry(const std::shared_ptr<Track>& track)
+            : track(track)
+        {
+        }
+    };
+    std::vector<TrackEntry> mTrackEntryList SRTC_GUARDED_BY(mMutex);
 
     // Sender and receiver reports
     void sendReports();

--- a/include/srtc/peer_connection.h
+++ b/include/srtc/peer_connection.h
@@ -196,7 +196,7 @@ private:
         {
         }
     };
-    std::vector<MediaEntry> mMediaEntryList SRTC_GUARDED_BY(mMutex);
+    std::vector<MediaEntry> mMediaEntryList;
 
     // Tracks
     struct TrackEntry {
@@ -214,7 +214,7 @@ private:
         {
         }
     };
-    std::vector<TrackEntry> mTrackEntryList SRTC_GUARDED_BY(mMutex);
+    std::vector<TrackEntry> mTrackEntryList;
 
     // Sender and receiver reports
     void sendReports();

--- a/include/srtc/publish_config.h
+++ b/include/srtc/publish_config.h
@@ -9,24 +9,22 @@
 namespace srtc
 {
 
-struct PubVideoCodec {
-    Codec codec;
-    uint32_t profile_level_id; // for h264
+struct PubCodec {
+    Codec codec = Codec::H264;
+    uint32_t profile_level_id = 0; // for h264
+    uint32_t minptime = 10;        // for audio
+    bool stereo = false;
 };
 
-struct PubVideoConfig {
-    std::vector<PubVideoCodec> codec_list;
-    std::vector<SimulcastLayer> simulcast_layer_list;
+struct PubMediaItem {
+    std::string media_id;
+    MediaType media_type;
+    std::vector<PubCodec> codec_list;
+    std::vector<SimulcastLayer> layer_list;
 };
 
-struct PubAudioCodec {
-    Codec codec;
-    uint32_t minptime;
-    bool stereo;
-};
-
-struct PubAudioConfig {
-    std::vector<PubAudioCodec> codec_list;
+struct PubMediaConfig {
+    std::vector<PubMediaItem> media_list;
 };
 
 } // namespace srtc

--- a/include/srtc/rtp_extension_source_simulcast.h
+++ b/include/srtc/rtp_extension_source_simulcast.h
@@ -18,17 +18,10 @@ class RtpExtensionBuilder;
 class RtpExtensionSourceSimulcast : public RtpExtensionSource
 {
 public:
-	RtpExtensionSourceSimulcast(uint8_t nVideoExtMediaId,
-								uint8_t nVideoExtStreamId,
-								uint8_t nVideoExtRepairedStreamId,
-								uint8_t nVideoExtGoogleVLA);
+	RtpExtensionSourceSimulcast();
 	~RtpExtensionSourceSimulcast() override;
 
-	static std::shared_ptr<RtpExtensionSourceSimulcast> factory(bool isVideoSimulcast,
-																uint8_t nVideoExtMediaId,
-																uint8_t nVideoExtStreamId,
-																uint8_t nVideoExtRepairedStreamId,
-																uint8_t nVideoExtGoogleVLA);
+	static std::shared_ptr<RtpExtensionSourceSimulcast> factory(bool isVideoSimulcast);
 
 	[[nodiscard]] bool shouldAdd(const std::shared_ptr<Track>& track,
 								 const std::shared_ptr<Packetizer>& packetizer,
@@ -51,15 +44,13 @@ public:
 	void updateForRtx(RtpExtensionBuilder& builder, const std::shared_ptr<Track>& track) const;
 
 private:
-	const uint8_t mVideoExtMediaId;
-	const uint8_t mVideoExtStreamId;
-	const uint8_t mVideoExtRepairedStreamId;
-	const uint8_t mVideoExtGoogleVLA;
-	const bool mIsExtensionsValid;
-
 	std::string mCurMediaId;
 	std::string mCurLayerName;
 	ByteBuffer mCurGoogleVLA;
+
+    uint8_t mCurExtMediaId;
+    uint8_t mCurExtStreamId;
+    uint8_t mCurExtGoogleVLA;
 };
 
 } // namespace srtc

--- a/include/srtc/rtp_extension_source_twcc.h
+++ b/include/srtc/rtp_extension_source_twcc.h
@@ -31,9 +31,7 @@ class RealScheduler;
 class RtpExtensionSourceTWCC : public RtpExtensionSource
 {
 public:
-    RtpExtensionSourceTWCC(uint8_t nVideoExtTWCC,
-                           uint8_t nAudioExtTWCC,
-                           const std::shared_ptr<RealScheduler>& scheduler);
+    RtpExtensionSourceTWCC(const std::shared_ptr<RealScheduler>& scheduler);
     ~RtpExtensionSourceTWCC() override;
 
     static std::shared_ptr<RtpExtensionSourceTWCC> factory(const std::shared_ptr<SdpOffer>& offer,
@@ -67,8 +65,6 @@ public:
     void updatePublishConnectionStats(PublishConnectionStats& stats) const;
 
 private:
-    const uint8_t mVideoExtTWCC;
-    const uint8_t mAudioExtTWCC;
     uint16_t mNextPacketSEQ;
     std::unique_ptr<twcc::PublishPacketHistory> mPacketHistory;
 

--- a/include/srtc/rtp_responder_twcc.h
+++ b/include/srtc/rtp_responder_twcc.h
@@ -21,7 +21,7 @@ class Track;
 class RtpResponderTWCC final
 {
 public:
-    RtpResponderTWCC(uint8_t nVideoExtTWCC, uint8_t nAudioExtTWCC);
+    RtpResponderTWCC();
     ~RtpResponderTWCC();
 
     static std::shared_ptr<RtpResponderTWCC> factory(const std::shared_ptr<SdpOffer>& offer,
@@ -33,9 +33,6 @@ public:
 
 private:
     const std::unique_ptr<twcc::SubscribePacketHistory> mPacketHistory;
-
-    uint8_t mVideoExtTWCC;
-    uint8_t mAudioExtTWCC;
 
     [[nodiscard]] uint8_t getExtensionId(const std::shared_ptr<Track>& track) const;
 };

--- a/include/srtc/scheduler.h
+++ b/include/srtc/scheduler.h
@@ -40,7 +40,7 @@ public:
     virtual ~Scheduler();
 
     using Delay = std::chrono::milliseconds;
-    using Func = std::function<void(void)>;
+    using Func = std::function<void()>;
 
     std::weak_ptr<Task> submit(const char* file, int line, const Func& func)
     {

--- a/include/srtc/sdp_answer.h
+++ b/include/srtc/sdp_answer.h
@@ -38,13 +38,10 @@ public:
     [[nodiscard]] std::string getIceUFrag() const;
     [[nodiscard]] std::string getIcePassword() const;
     [[nodiscard]] std::vector<Host> getHostList() const;
-    [[nodiscard]] bool isVideoSimulcast() const;
-    [[nodiscard]] std::shared_ptr<Track> getVideoSingleTrack() const;
-    [[nodiscard]] std::vector<std::shared_ptr<Track>> getVideoSimulcastTrackList() const;
-    [[nodiscard]] std::shared_ptr<Track> getAudioTrack() const;
     [[nodiscard]] std::vector<std::shared_ptr<Media>> getMediaList() const;
     [[nodiscard]] std::vector<std::shared_ptr<Track>> getTrackList() const;
     [[nodiscard]] bool isSetupActive() const;
+    [[nodiscard]] bool isVideoSimulcast() const;
     [[nodiscard]] const X509Hash& getCertificateHash() const;
     [[nodiscard]] bool hasDataChannel() const;
     [[nodiscard]] uint16_t getSctpPort() const;

--- a/include/srtc/sdp_answer.h
+++ b/include/srtc/sdp_answer.h
@@ -43,8 +43,6 @@ public:
     [[nodiscard]] std::vector<std::shared_ptr<Track>> getVideoSimulcastTrackList() const;
     [[nodiscard]] bool hasAudioMedia() const;
     [[nodiscard]] std::shared_ptr<Track> getAudioTrack() const;
-    [[nodiscard]] const ExtensionMap& getVideoExtensionMap() const;
-    [[nodiscard]] const ExtensionMap& getAudioExtensionMap() const;
     [[nodiscard]] bool isSetupActive() const;
     [[nodiscard]] const X509Hash& getCertificateHash() const;
     [[nodiscard]] bool hasDataChannel() const;
@@ -59,8 +57,6 @@ private:
     const std::shared_ptr<Track> mVideoSingleTrack;
     const std::vector<std::shared_ptr<Track>> mVideoSimulcastTrackList;
     const std::shared_ptr<Track> mAudioTrack;
-    const ExtensionMap mVideoExtensionMap;
-    const ExtensionMap mAudioExtensionMap;
     const bool mIsSetupActive;
     const X509Hash mCertHash;
     const bool mHasDataChannel;
@@ -74,8 +70,6 @@ private:
               const std::shared_ptr<Track>& videoSingleTrack,
               const std::vector<std::shared_ptr<Track>>& videoSimulcastTrackList,
               const std::shared_ptr<Track>& audioTrack,
-              const ExtensionMap& videoExtensionMap,
-              const ExtensionMap& audioExtensionMap,
               bool isSetupActive,
               const X509Hash& certHash,
               bool hasDataChannel,

--- a/include/srtc/sdp_answer.h
+++ b/include/srtc/sdp_answer.h
@@ -14,6 +14,7 @@ namespace srtc
 {
 
 class SdpOffer;
+class Media;
 class Track;
 class PeerConnection;
 class TrackSelector;
@@ -37,12 +38,12 @@ public:
     [[nodiscard]] std::string getIceUFrag() const;
     [[nodiscard]] std::string getIcePassword() const;
     [[nodiscard]] std::vector<Host> getHostList() const;
-    [[nodiscard]] bool hasVideoMedia() const;
     [[nodiscard]] bool isVideoSimulcast() const;
     [[nodiscard]] std::shared_ptr<Track> getVideoSingleTrack() const;
     [[nodiscard]] std::vector<std::shared_ptr<Track>> getVideoSimulcastTrackList() const;
-    [[nodiscard]] bool hasAudioMedia() const;
     [[nodiscard]] std::shared_ptr<Track> getAudioTrack() const;
+    [[nodiscard]] std::vector<std::shared_ptr<Media>> getMediaList() const;
+    [[nodiscard]] std::vector<std::shared_ptr<Track>> getTrackList() const;
     [[nodiscard]] bool isSetupActive() const;
     [[nodiscard]] const X509Hash& getCertificateHash() const;
     [[nodiscard]] bool hasDataChannel() const;
@@ -54,9 +55,8 @@ private:
     const std::string mIceUFrag;
     const std::string mIcePassword;
     const std::vector<Host> mHostList;
-    const std::shared_ptr<Track> mVideoSingleTrack;
-    const std::vector<std::shared_ptr<Track>> mVideoSimulcastTrackList;
-    const std::shared_ptr<Track> mAudioTrack;
+    const std::vector<std::shared_ptr<Media>> mMediaList;
+    const std::vector<std::shared_ptr<Track>> mTrackList;
     const bool mIsSetupActive;
     const X509Hash mCertHash;
     const bool mHasDataChannel;
@@ -67,9 +67,8 @@ private:
 			  const std::string& iceUFrag,
               const std::string& icePassword,
               const std::vector<Host>& hostList,
-              const std::shared_ptr<Track>& videoSingleTrack,
-              const std::vector<std::shared_ptr<Track>>& videoSimulcastTrackList,
-              const std::shared_ptr<Track>& audioTrack,
+              const std::vector<std::shared_ptr<Media>>& mediaList,
+              const std::vector<std::shared_ptr<Track>>& trackList,
               bool isSetupActive,
               const X509Hash& certHash,
               bool hasDataChannel,

--- a/include/srtc/sdp_offer.h
+++ b/include/srtc/sdp_offer.h
@@ -30,7 +30,6 @@ struct PubOfferConfig {
     bool enable_rtx = true;
     bool enable_bwe = false;
     bool enable_rfc8851 = false;
-    bool debug_drop_packets = false;
     DataChannelConfig data_channel_config;
 };
 
@@ -39,7 +38,6 @@ struct SubOfferConfig {
     uint16_t pli_interval_millis = 2000;
     uint16_t jitter_buffer_length_millis = 0;
     uint16_t jitter_buffer_nack_delay_millis = 0;
-    bool debug_drop_packets = false;
     DataChannelConfig data_channel_config;
 };
 
@@ -53,7 +51,6 @@ private:
     struct Config {
         // Common
         std::string cname;
-        bool debug_drop_packets = false;
         // Data channels
         std::vector<std::string> data_channels;
         // Publish

--- a/include/srtc/sdp_offer.h
+++ b/include/srtc/sdp_offer.h
@@ -66,43 +66,29 @@ private:
         uint16_t jitter_buffer_nack_delay_millis = 0;
     };
 
-    struct VideoCodec {
+    struct MediaCodec {
         Codec codec;
         uint32_t profile_level_id; // for h264
-
-        VideoCodec(Codec codec, uint32_t profile_level_id)
-            : codec(codec)
-            , profile_level_id(profile_level_id)
-        {
-        }
-    };
-
-    struct VideoConfig {
-        std::vector<VideoCodec> codec_list;
-        std::vector<SimulcastLayer> simulcast_layer_list;
-    };
-
-    struct AudioCodec {
-        Codec codec;
-        uint32_t minptime;
+        uint32_t minptime;         // for audio
         bool stereo;
 
-        AudioCodec(Codec codec, uint32_t minptime, bool stereo)
+        MediaCodec(Codec codec, uint32_t profile_level_id, uint32_t minptime, bool stereo)
             : codec(codec)
+            , profile_level_id(profile_level_id)
             , minptime(minptime)
             , stereo(stereo)
         {
         }
     };
 
-    struct AudioConfig {
-        std::vector<AudioCodec> codec_list;
+    struct MediaLine {
+        std::string id;
+        MediaType mediaType;
+        std::vector<MediaCodec> codec_list;
+        std::vector<SimulcastLayer> layer_list;
     };
 
-    SdpOffer(Direction direction,
-             const Config& config,
-             const std::optional<VideoConfig>& videoConfig,
-             const std::optional<AudioConfig>& audioConfig);
+    SdpOffer(Direction direction, const Config& config, const std::vector<MediaLine>& media);
 
 public:
     ~SdpOffer() = default;
@@ -113,17 +99,16 @@ public:
 
     [[nodiscard]] std::pair<std::string, Error> generate();
 
-    [[nodiscard]] std::optional<std::vector<SimulcastLayer>> getVideoSimulcastLayerList() const;
     [[nodiscard]] std::string getIceUFrag() const;
     [[nodiscard]] std::string getIcePassword() const;
     [[nodiscard]] std::shared_ptr<X509Certificate> getCertificate() const;
 
-    [[nodiscard]] uint32_t getVideoSSRC() const;
-    [[nodiscard]] uint32_t getRtxVideoSSRC() const;
-    [[nodiscard]] uint32_t getAudioSSRC() const;
-    [[nodiscard]] uint32_t getRtxAudioSSRC() const;
+    [[nodiscard]] std::optional<std::vector<SimulcastLayer>> getVideoSimulcastLayerList(
+        const std::string& mediaId) const;
 
-    [[nodiscard]] std::pair<uint32_t, uint32_t> getVideoSimulastSSRC(const std::string& name) const;
+    [[nodiscard]] std::pair<uint32_t, uint32_t> getMediaSSRC(const std::string& mediaId) const;
+    [[nodiscard]] std::pair<uint32_t, uint32_t> getVideoSimulastSSRC(const std::string& mediaId,
+                                                                     const std::string& rid) const;
 
     [[nodiscard]] bool hasDataChannel() const;
     [[nodiscard]] uint16_t getSctpPort() const;
@@ -137,30 +122,40 @@ private:
 
     const Direction mDirection;
     const Config mConfig;
-    const std::optional<VideoConfig> mVideoConfig;
-    const std::optional<AudioConfig> mAudioConfig;
+    const std::vector<MediaLine> mMediaLineList;
 
     const uint64_t mOriginId;
-
-    const uint32_t mVideoSSRC;
-    const uint32_t mRtxVideoSSRC;
-    const uint32_t mAudioSSRC;
-    const uint32_t mRtxAudioSSRC;
-
-    const std::string mVideoMSID;
-    const std::string mAudioMSID;
 
     const std::string mIceUfrag;
     const std::string mIcePassword;
 
     const std::shared_ptr<X509Certificate> mCert;
 
-    struct LayerSSRC {
+    struct LayerGenerated {
         std::string name;
-        uint32_t ssrc;
-        uint32_t rtx;
+        uint32_t ssrc = 0;
+        uint32_t rtx = 0;
+
+        LayerGenerated(const std::string& name)
+            : name(name)
+        {
+        }
     };
-    std::vector<LayerSSRC> mLayerSSRC;
+
+    struct MediaLineGenerated {
+        std::string mediaId;
+        MediaType mediaType;
+        uint32_t ssrc = 0;
+        uint32_t rtx = 0;
+        std::vector<LayerGenerated> layer;
+
+        MediaLineGenerated(const std::string& mediaId)
+            : mediaId(mediaId)
+        {
+        }
+    };
+
+    std::vector<MediaLineGenerated> mMediaLineGeneratedList;
 };
 
 } // namespace srtc

--- a/include/srtc/srtc.h
+++ b/include/srtc/srtc.h
@@ -31,6 +31,9 @@ enum class Codec {
     Rtx = 200
 };
 
+bool isVideoCodec(Codec codec);
+bool isAudioCodec(Codec codec);
+
 enum class MediaType {
     Video = 1,
     Audio = 2

--- a/include/srtc/subscribe_config.h
+++ b/include/srtc/subscribe_config.h
@@ -8,23 +8,22 @@
 namespace srtc
 {
 
-struct SubVideoCodec {
-	Codec codec;
-	uint32_t profile_level_id; // for h264
+struct SubCodec {
+	Codec codec = Codec::H264;
+	uint32_t profile_level_id = 0;  // for h264
+    uint32_t minptime = 10;         // for audio
+    bool stereo = false;
 };
 
-struct SubVideoConfig {
-	std::vector<SubVideoCodec> codec_list;
+struct SubMediaItem {
+    std::string media_id;
+    MediaType media_type;
+    std::vector<SubCodec> codec_list;
 };
 
-struct SubAudioCodec {
-	Codec codec;
-	uint32_t minptime;
-	bool stereo;
+struct SubMediaConfig {
+    std::vector<SubMediaItem> media_list;
 };
 
-struct SubAudioConfig {
-	std::vector<SubAudioCodec> codec_list;
-};
 
 }

--- a/include/srtc/track.h
+++ b/include/srtc/track.h
@@ -51,6 +51,7 @@ public:
           bool hasPli);
 
     [[nodiscard]] std::shared_ptr<Media> getMedia() const;
+    [[nodiscard]] MediaType getMediaType() const;
     [[nodiscard]] Direction getDirection() const;
     [[nodiscard]] uint8_t getPayloadId() const;
     [[nodiscard]] uint8_t getRtxPayloadId() const;

--- a/include/srtc/track.h
+++ b/include/srtc/track.h
@@ -3,7 +3,6 @@
 #include "srtc/simulcast_layer.h"
 #include "srtc/srtc.h"
 
-#include <atomic>
 #include <memory>
 #include <string>
 
@@ -13,6 +12,7 @@ namespace srtc
 class RtcpPacketSource;
 class RtpTimeSource;
 class RtpPacketSource;
+class Media;
 class TrackStats;
 
 class Track
@@ -37,10 +37,8 @@ public:
         }
     };
 
-    Track(uint32_t trackId,
+    Track(const std::shared_ptr<Media>& media,
           Direction direction,
-          MediaType mediaType,
-          const std::string& mediaId,
           uint32_t ssrc,
           uint8_t payloadId,
           uint32_t rtxSsrc,
@@ -52,10 +50,8 @@ public:
           bool hasNack,
           bool hasPli);
 
-    [[nodiscard]] uint32_t getTrackId() const;
+    [[nodiscard]] std::shared_ptr<Media> getMedia() const;
     [[nodiscard]] Direction getDirection() const;
-    [[nodiscard]] MediaType getMediaType() const;
-    [[nodiscard]] std::string getMediaId() const;
     [[nodiscard]] uint8_t getPayloadId() const;
     [[nodiscard]] uint8_t getRtxPayloadId() const;
     [[nodiscard]] Codec getCodec() const;
@@ -77,10 +73,8 @@ public:
     [[nodiscard]] std::shared_ptr<TrackStats> getStats() const;
 
 private:
-    const uint32_t mTrackId;
+    const std::shared_ptr<Media> mMedia;
     const Direction mDirection;
-    const MediaType mMediaType;
-    const std::string mMediaId;
     const uint32_t mSSRC;
     const uint8_t mPayloadId;
     const uint32_t mRtxSSRC;
@@ -101,13 +95,8 @@ private:
 class TrackBuilder
 {
 public:
-    TrackBuilder(uint32_t trackId,
-                 Direction direction,
-                 MediaType mediaType,
-                 const std::string& mediaId,
-                 uint32_t ssrc,
-                 uint8_t payloadId,
-                 uint32_t clockRate);
+    TrackBuilder(
+        const std::shared_ptr<Media>& media, Direction direction, uint32_t ssrc, uint8_t payloadId, uint32_t clockRate);
 
     TrackBuilder& rtx(uint32_t rtxSsrc, uint8_t rtxPayloadId);
     TrackBuilder& codec(Codec codec, const std::shared_ptr<Track::CodecOptions>& codecOptions);
@@ -118,10 +107,8 @@ public:
     [[nodiscard]] std::shared_ptr<Track> build() const;
 
 private:
-    const uint32_t mTrackId;
+    const std::shared_ptr<Media> mMedia;
     const Direction mDirection;
-    const MediaType mMediaType;
-    const std::string mMediaId;
     const uint32_t mSSRC;
     const uint8_t mPayloadId;
     const uint32_t mClockRate;

--- a/include/srtc/track_selector.h
+++ b/include/srtc/track_selector.h
@@ -8,6 +8,7 @@
 namespace srtc
 {
 
+class Media;
 class Track;
 
 class TrackSelector
@@ -15,17 +16,15 @@ class TrackSelector
 public:
     virtual ~TrackSelector() = default;
 
-    [[nodiscard]] virtual std::shared_ptr<Track> selectTrack(MediaType type,
-                                                             const std::vector<std::shared_ptr<Track>>& list) const = 0;
+    [[nodiscard]] virtual std::shared_ptr<Track> selectTrack(const std::vector<std::shared_ptr<Track>>& list) const = 0;
 };
 
-class HighestTrackSelector : public srtc::TrackSelector
+class HighestTrackSelector : public TrackSelector
 {
 public:
     ~HighestTrackSelector() override = default;
 
-    [[nodiscard]] std::shared_ptr<srtc::Track> selectTrack(
-        srtc::MediaType type, const std::vector<std::shared_ptr<srtc::Track>>& list) const override;
+    [[nodiscard]] std::shared_ptr<Track> selectTrack(const std::vector<std::shared_ptr<Track>>& list) const override;
 };
 
 } // namespace srtc

--- a/src/depacketizer_video.cpp
+++ b/src/depacketizer_video.cpp
@@ -11,7 +11,7 @@ namespace srtc
 DepacketizerVideo::DepacketizerVideo(const std::shared_ptr<Track>& track)
     : Depacketizer(track)
 {
-    assert(track->getMedia()->getType() == MediaType::Video);
+    assert(track->getMediaType() == MediaType::Video);
 }
 
 DepacketizerVideo::~DepacketizerVideo() = default;

--- a/src/depacketizer_video.cpp
+++ b/src/depacketizer_video.cpp
@@ -1,4 +1,6 @@
 #include "srtc/depacketizer_video.h"
+
+#include "srtc/media.h"
 #include "srtc/track.h"
 
 #include <cassert>
@@ -9,7 +11,7 @@ namespace srtc
 DepacketizerVideo::DepacketizerVideo(const std::shared_ptr<Track>& track)
     : Depacketizer(track)
 {
-    assert(track->getMediaType() == MediaType::Video);
+    assert(track->getMedia()->getType() == MediaType::Video);
 }
 
 DepacketizerVideo::~DepacketizerVideo() = default;

--- a/src/extension_map.cpp
+++ b/src/extension_map.cpp
@@ -3,6 +3,14 @@
 namespace srtc
 {
 
+ExtensionMap::ExtensionMap() : mLastId(0)
+{
+}
+
+ExtensionMap::~ExtensionMap()
+{
+}
+
 void ExtensionMap::add(uint8_t id, const std::string& name)
 {
     mEntryList.emplace_back(id, name);
@@ -10,8 +18,15 @@ void ExtensionMap::add(uint8_t id, const std::string& name)
 
 uint8_t ExtensionMap::findByName(const std::string& name) const
 {
+    if (mLastName == name) {
+        return mLastId;
+    }
+
     for (const auto& entry : mEntryList) {
         if (entry.name == name) {
+            mLastName = name;
+            mLastId = entry.id;
+
             return entry.id;
         }
     }
@@ -21,8 +36,15 @@ uint8_t ExtensionMap::findByName(const std::string& name) const
 
 std::string ExtensionMap::findById(uint8_t id) const
 {
+    if (mLastId == id) {
+        return mLastName;
+    }
+
     for (const auto& entry : mEntryList) {
         if (entry.id == id) {
+            mLastName = entry.name;
+            mLastId = entry.id;
+
             return entry.name;
         }
     }

--- a/src/extension_map.cpp
+++ b/src/extension_map.cpp
@@ -52,4 +52,11 @@ std::string ExtensionMap::findById(uint8_t id) const
     return {};
 }
 
+void ExtensionMap::clear()
+{
+    mLastName.clear();
+    mLastId = 0;
+    mEntryList.clear();
+}
+
 } // namespace srtc

--- a/src/jitter_buffer.cpp
+++ b/src/jitter_buffer.cpp
@@ -59,7 +59,7 @@ JitterBuffer::JitterBuffer(const std::shared_ptr<Track>& track,
 
     LOG(SRTC_LOG_V,
         "Constructed for %s with length = %ld, nack delay = %ld",
-        to_string(mTrack->getMedia()->getType()).c_str(),
+        to_string(mTrack->getMediaType()).c_str(),
         static_cast<long>(length.count()),
         static_cast<long>(nackDelay.count()));
 }
@@ -641,7 +641,7 @@ void JitterBuffer::appendToResult(std::vector<std::shared_ptr<EncodedFrame>>& re
         if (mLastFrameTimeStamp.has_value() && mLastFrameTimeStamp.value() > item->rtp_timestamp_ext) {
             LOG(SRTC_LOG_W,
                 "Will not de-queue %s frame with ts = %" PRIu64 ", because it's older than last frame time %" PRIu64,
-                to_string(mTrack->getMedia()->getType()).c_str(),
+                to_string(mTrack->getMediaType()).c_str(),
                 item->rtp_timestamp_ext,
                 mLastFrameTimeStamp.value());
             return;

--- a/src/jitter_buffer.cpp
+++ b/src/jitter_buffer.cpp
@@ -1,6 +1,7 @@
 #include "srtc/jitter_buffer.h"
 #include "srtc/depacketizer.h"
 #include "srtc/logging.h"
+#include "srtc/media.h"
 #include "srtc/rtp_packet.h"
 #include "srtc/track.h"
 
@@ -58,7 +59,7 @@ JitterBuffer::JitterBuffer(const std::shared_ptr<Track>& track,
 
     LOG(SRTC_LOG_V,
         "Constructed for %s with length = %ld, nack delay = %ld",
-        to_string(mTrack->getMediaType()).c_str(),
+        to_string(mTrack->getMedia()->getType()).c_str(),
         static_cast<long>(length.count()),
         static_cast<long>(nackDelay.count()));
 }
@@ -76,6 +77,8 @@ std::shared_ptr<Track> JitterBuffer::getTrack() const
 void JitterBuffer::consume(const std::shared_ptr<RtpPacket>& packet)
 {
     assert(mTrack == packet->getTrack());
+
+    const auto media = mTrack->getMedia();
 
     auto seq = packet->getSequence();
     auto payload = packet->movePayload();
@@ -101,7 +104,7 @@ void JitterBuffer::consume(const std::shared_ptr<RtpPacket>& packet)
     if (mLastFrameTimeStamp.has_value() && mLastFrameTimeStamp.value() > rtp_timestamp_ext) {
         LOG(SRTC_LOG_W,
             "Will not en-queue %s frame with ts = %" PRIu64 ", because it's older than last frame time %" PRIu64,
-            to_string(mTrack->getMediaType()).c_str(),
+            to_string(media->getType()).c_str(),
             rtp_timestamp_ext,
             mLastFrameTimeStamp.value());
         return;
@@ -115,7 +118,7 @@ void JitterBuffer::consume(const std::shared_ptr<RtpPacket>& packet)
         if (elapsed >= kNoPacketsResetDelay && seq_ext >= mMaxSeq + mCapacity / 8) {
             LOG(SRTC_LOG_E,
                 "We have not had %s packets for %ld milliseconds, resetting the jitter buffer",
-                to_string(mTrack->getMediaType()).c_str(),
+                to_string(media->getType()).c_str(),
                 static_cast<long>(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count()));
             freeEverything();
             mDepacketizer->reset();
@@ -142,7 +145,7 @@ void JitterBuffer::consume(const std::shared_ptr<RtpPacket>& packet)
             "The new packet SEQ = %u is too late, SSRC = %u, media = %s, min = %u, max = %u",
             seq,
             mTrack->getSSRC(),
-            to_string(mTrack->getMediaType()).c_str(),
+            to_string(media->getType()).c_str(),
             static_cast<uint16_t>(mMinSeq),
             static_cast<uint16_t>(mMaxSeq));
         return;
@@ -152,7 +155,7 @@ void JitterBuffer::consume(const std::shared_ptr<RtpPacket>& packet)
             "The new packet SEQ = %u is too early, SSRC = %u, media = %s, min = %u, max = %u",
             seq,
             mTrack->getSSRC(),
-            to_string(mTrack->getMediaType()).c_str(),
+            to_string(media->getType()).c_str(),
             static_cast<uint16_t>(mMinSeq),
             static_cast<uint16_t>(mMaxSeq));
         return;
@@ -174,7 +177,7 @@ void JitterBuffer::consume(const std::shared_ptr<RtpPacket>& packet)
                 "The new packet with SEQ = %u would exceed the capacity, SSRC = %u, media = %s, min = %u, max = %u",
                 static_cast<uint16_t>(seq_ext),
                 mTrack->getSSRC(),
-                to_string(mTrack->getMediaType()).c_str(),
+                to_string(media->getType()).c_str(),
                 static_cast<uint16_t>(mMinSeq),
                 static_cast<uint16_t>(mMaxSeq));
             return;
@@ -214,7 +217,7 @@ void JitterBuffer::consume(const std::shared_ptr<RtpPacket>& packet)
                 "The new packet with SEQ = %u would exceed the capacity, SSRC = %u, media = %s, min = %u, max = %u",
                 static_cast<uint16_t>(seq_ext),
                 mTrack->getSSRC(),
-                to_string(mTrack->getMediaType()).c_str(),
+                to_string(media->getType()).c_str(),
                 static_cast<uint16_t>(mMinSeq),
                 static_cast<uint16_t>(mMaxSeq));
             return;
@@ -638,7 +641,7 @@ void JitterBuffer::appendToResult(std::vector<std::shared_ptr<EncodedFrame>>& re
         if (mLastFrameTimeStamp.has_value() && mLastFrameTimeStamp.value() > item->rtp_timestamp_ext) {
             LOG(SRTC_LOG_W,
                 "Will not de-queue %s frame with ts = %" PRIu64 ", because it's older than last frame time %" PRIu64,
-                to_string(mTrack->getMediaType()).c_str(),
+                to_string(mTrack->getMedia()->getType()).c_str(),
                 item->rtp_timestamp_ext,
                 mLastFrameTimeStamp.value());
             return;

--- a/src/media.cpp
+++ b/src/media.cpp
@@ -1,0 +1,26 @@
+#include "srtc/media.h"
+
+namespace srtc
+{
+
+Media::Media(const std::string& id, MediaType type)
+    : mId(id)
+    , mType(type)
+{
+}
+
+Media::~Media()
+{
+}
+
+std::string Media::getId() const
+{
+    return mId;
+}
+
+MediaType Media::getType() const
+{
+    return mType;
+}
+
+} // namespace srtc

--- a/src/media.cpp
+++ b/src/media.cpp
@@ -9,6 +9,13 @@ Media::Media(const std::string& id, MediaType type)
 {
 }
 
+Media::Media(const std::string& id, MediaType type, const ExtensionMap& extensionMap)
+    : mId(id)
+    , mType(type)
+    , mExtensionMap(extensionMap)
+{
+}
+
 Media::~Media()
 {
 }
@@ -21,6 +28,11 @@ std::string Media::getId() const
 MediaType Media::getType() const
 {
     return mType;
+}
+
+const ExtensionMap& Media::getExtensionMap() const
+{
+    return mExtensionMap;
 }
 
 } // namespace srtc

--- a/src/peer_candidate.cpp
+++ b/src/peer_candidate.cpp
@@ -301,9 +301,9 @@ void PeerCandidate::addSendFrame(FrameToSend&& frame)
     mFrameSendQueue.push_back(std::move(frame));
 }
 
-void PeerCandidate::sendSenderReports(const std::vector<std::shared_ptr<Track>>& trackList)
+void PeerCandidate::sendSenderReports()
 {
-    for (const auto& track : trackList) {
+    for (const auto& track : mTrackList) {
         if (track->getDirection() == Direction::Publish) {
             const auto ssrc = track->getSSRC();
 
@@ -334,9 +334,9 @@ void PeerCandidate::sendSenderReports(const std::vector<std::shared_ptr<Track>>&
     }
 }
 
-void PeerCandidate::sendReceiverReports(const std::vector<std::shared_ptr<Track>>& trackList)
+void PeerCandidate::sendReceiverReports()
 {
-    for (const auto& track : trackList) {
+    for (const auto& track : mTrackList) {
         const auto direction = track->getDirection();
         if (direction == Direction::Subscribe) {
             const auto ssrc = track->getSSRC();
@@ -374,10 +374,10 @@ void PeerCandidate::sendReceiverReports(const std::vector<std::shared_ptr<Track>
     }
 }
 
-void PeerCandidate::sendPictureLossIndicators(const std::vector<std::shared_ptr<Track>>& trackList)
+void PeerCandidate::sendPictureLossIndicators()
 {
-    for (const auto& track : trackList) {
-        if (track->getMedia()->getType() == MediaType::Video && track->getDirection() == Direction::Subscribe) {
+    for (const auto& track : mTrackList) {
+        if (track->getMediaType() == MediaType::Video && track->getDirection() == Direction::Subscribe) {
             const auto ssrc = track->getSSRC();
 
             LOG(SRTC_LOG_V, "Sending PLI for ssrc = %u", ssrc);
@@ -419,7 +419,7 @@ void PeerCandidate::sendNacks(const std::shared_ptr<Track>& track, const std::ve
 
         LOG(SRTC_LOG_V,
             "Sending NACK for media %s, SSRC = %u, SEQ = %u, BLP = 0x%x",
-            to_string(track->getMedia()->getType()).c_str(),
+            to_string(track->getMediaType()).c_str(),
             ssrc,
             seq,
             blp);
@@ -571,13 +571,14 @@ void PeerCandidate::run()
 
         if (!item.buf.empty()) {
             // Simulcast layer list
-            const auto& layerList = mListener->getSimulcastLayerList();
+            mSimulcastLayerList.clear();
+            mListener->getSimulcastLayerList(item.track->getMedia(), mSimulcastLayerList);
 
             // Frame data
             if (mExtensionSourceSimulcast) {
-                if (item.track->getMedia()->getType() == MediaType::Video && item.track->isSimulcast() &&
+                if (item.track->getMediaType() == MediaType::Video && item.track->isSimulcast() &&
                     mExtensionSourceSimulcast->shouldAdd(item.track, item.packetizer, item.buf)) {
-                    mExtensionSourceSimulcast->prepare(item.track, layerList);
+                    mExtensionSourceSimulcast->prepare(item.track, mSimulcastLayerList);
                 } else {
                     mExtensionSourceSimulcast->clear();
                 }
@@ -604,7 +605,7 @@ void PeerCandidate::run()
                         auto bandwidthScale = 1.0f;
                         if (item.track->isSimulcast()) {
                             // Each layer gets a portion of the total bandwidth
-                            bandwidthScale = calculateLayerBandwidthScale(layerList, item.track->getSimulcastLayer());
+                            bandwidthScale = calculateLayerBandwidthScale(mSimulcastLayerList, item.track->getSimulcastLayer());
                         }
                         spread = mExtensionSourceTWCC->getPacingSpreadMillis(packetList, bandwidthScale, spread);
                     }
@@ -938,27 +939,6 @@ void PeerCandidate::onReceivedRtcMessage(ByteBuffer&& buf)
                 }
             }
         } else {
-#ifdef NDEBUG
-#else
-            {
-                const auto config = mOffer->getConfig();
-                const auto randomValue = mLosePacketsRandomGenerator.next();
-
-                // In debug mode, we have deliberate 5% packet loss to validate that NACK / RTX processing works
-                const auto seq = ntohs(*reinterpret_cast<const uint16_t*>(buf.data() + 2));
-                const auto ssrc = ntohl(*reinterpret_cast<const uint32_t*>(buf.data() + 8));
-
-                if (ssrc == mAnswer->getVideoSingleTrack()->getSSRC()) {
-                    if (config.debug_drop_packets && randomValue < 5) {
-                        if (mLosePacketHistory.shouldLosePacket(ssrc, seq)) {
-                            LOG(SRTC_LOG_V, "Dropping incoming packet with SSRC = %u, SEQ = %u", ssrc, seq);
-                            return;
-                        }
-                    }
-                }
-            }
-#endif
-
             if (mSrtpConnection->unprotectReceiveMedia(buf, output)) {
                 LOG(SRTC_LOG_V, "RTP unprotect: size = %zd", output.size());
 
@@ -1041,7 +1021,7 @@ void PeerCandidate::onReceivedMediaPacket(const std::shared_ptr<RtpPacket>& pack
 
     LOG(SRTC_LOG_V,
         "RTP media packet: media = %s, ssrc = %12" PRIu32 ", seq = %5u, pt = %u, size = %zu",
-        to_string(track->getMedia()->getType()).c_str(),
+        to_string(track->getMediaType()).c_str(),
         packet->getSSRC(),
         packet->getSequence(),
         packet->getPayloadId(),
@@ -1073,7 +1053,7 @@ void PeerCandidate::onReceivedControlMessage_200(uint32_t ssrc, srtc::ByteReader
                 ntp_low,
                 packet_count,
                 octet_count,
-                to_string(track->getMedia()->getType()).c_str());
+                to_string(track->getMediaType()).c_str());
 
             SenderReport sr;
             sr.when = std::chrono::steady_clock::now();

--- a/src/peer_candidate.cpp
+++ b/src/peer_candidate.cpp
@@ -9,6 +9,7 @@
 #include "srtc/event_loop.h"
 #include "srtc/ice_agent.h"
 #include "srtc/logging.h"
+#include "srtc/media.h"
 #include "srtc/packetizer.h"
 #include "srtc/peer_candidate.h"
 #include "srtc/rtcp_packet.h"
@@ -389,7 +390,7 @@ void PeerCandidate::sendReceiverReports(const std::vector<std::shared_ptr<Track>
 void PeerCandidate::sendPictureLossIndicators(const std::vector<std::shared_ptr<Track>>& trackList)
 {
     for (const auto& track : trackList) {
-        if (track->getMediaType() == MediaType::Video && track->getDirection() == Direction::Subscribe) {
+        if (track->getMedia()->getType() == MediaType::Video && track->getDirection() == Direction::Subscribe) {
             const auto ssrc = track->getSSRC();
 
             LOG(SRTC_LOG_V, "Sending PLI for ssrc = %u", ssrc);
@@ -431,7 +432,7 @@ void PeerCandidate::sendNacks(const std::shared_ptr<Track>& track, const std::ve
 
         LOG(SRTC_LOG_V,
             "Sending NACK for media %s, SSRC = %u, SEQ = %u, BLP = 0x%x",
-            to_string(track->getMediaType()).c_str(),
+            to_string(track->getMedia()->getType()).c_str(),
             ssrc,
             seq,
             blp);
@@ -587,7 +588,7 @@ void PeerCandidate::run()
 
             // Frame data
             if (mExtensionSourceSimulcast) {
-                if (item.track->getMediaType() == MediaType::Video && item.track->isSimulcast() &&
+                if (item.track->getMedia()->getType() == MediaType::Video && item.track->isSimulcast() &&
                     mExtensionSourceSimulcast->shouldAdd(item.track, item.packetizer, item.buf)) {
                     mExtensionSourceSimulcast->prepare(item.track, layerList);
                 } else {
@@ -1053,7 +1054,7 @@ void PeerCandidate::onReceivedMediaPacket(const std::shared_ptr<RtpPacket>& pack
 
     LOG(SRTC_LOG_V,
         "RTP media packet: media = %s, ssrc = %12" PRIu32 ", seq = %5u, pt = %u, size = %zu",
-        to_string(track->getMediaType()).c_str(),
+        to_string(track->getMedia()->getType()).c_str(),
         packet->getSSRC(),
         packet->getSequence(),
         packet->getPayloadId(),
@@ -1085,7 +1086,7 @@ void PeerCandidate::onReceivedControlMessage_200(uint32_t ssrc, srtc::ByteReader
                 ntp_low,
                 packet_count,
                 octet_count,
-                to_string(track->getMediaType()).c_str());
+                to_string(track->getMedia()->getType()).c_str());
 
             SenderReport sr;
             sr.when = std::chrono::steady_clock::now();
@@ -1398,7 +1399,6 @@ std::optional<float> PeerCandidate::calculateRtt(const std::chrono::steady_clock
     }
 
     return {};
-
 }
 
 // State

--- a/src/peer_candidate.cpp
+++ b/src/peer_candidate.cpp
@@ -189,11 +189,6 @@ bool is_rtcp_message(const srtc::ByteBuffer& buf)
     return false;
 }
 
-uint8_t findVideoExtension(const std::shared_ptr<srtc::SdpAnswer>& answer, const std::string& name)
-{
-    return answer->getVideoExtensionMap().findByName(name);
-}
-
 float calculateLayerBandwidthScale(const std::vector<srtc::SimulcastLayer>& layerList,
                                    const std::shared_ptr<srtc::SimulcastLayer>& trackLayer)
 {
@@ -234,15 +229,7 @@ PeerCandidate::PeerCandidate(PeerCandidateListener* const listener,
     , mIceMessageBuffer(std::make_unique<uint8_t[]>(kIceMessageBufferSize))
     , mSendRtpHistory(std::make_shared<SendRtpHistory>())
     , mUniqueId(++gNextUniqueId)
-    , mVideoExtMediaId(findVideoExtension(answer, RtpStandardExtensions::kExtSdesMid))
-    , mVideoExtStreamId(findVideoExtension(answer, RtpStandardExtensions::kExtSdesRtpStreamId))
-    , mVideoExtRepairedStreamId(findVideoExtension(answer, RtpStandardExtensions::kExtSdesRtpRepairedStreamId))
-    , mVideoExtGoogleVLA(findVideoExtension(answer, RtpStandardExtensions::kExtGoogleVLA))
-    , mExtensionSourceSimulcast(RtpExtensionSourceSimulcast::factory(answer->isVideoSimulcast(),
-                                                                     mVideoExtMediaId,
-                                                                     mVideoExtStreamId,
-                                                                     mVideoExtRepairedStreamId,
-                                                                     mVideoExtGoogleVLA))
+    , mExtensionSourceSimulcast(RtpExtensionSourceSimulcast::factory(answer->isVideoSimulcast()))
     , mExtensionSourceTWCC(RtpExtensionSourceTWCC::factory(offer, answer, scheduler))
     , mResponderTWCC(RtpResponderTWCC::factory(offer, answer))
     , mSenderReportsHistory(std::make_shared<SenderReportsHistory>())

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -30,6 +30,28 @@ constexpr auto kReportsInterval = std::chrono::seconds(1);
 constexpr auto kConnectionStatsInterval = std::chrono::seconds(5);
 constexpr auto kJitterBufferSize = 4096;
 
+template <typename T>
+srtc::Error validateMediaItem(const T& mediaItem)
+{
+    if (mediaItem.media_id.empty()) {
+        return { srtc::Error::Code::InvalidData, "The media id cannot be empty" };
+    }
+
+    for (const auto& codec : mediaItem.codec_list) {
+        if (mediaItem.media_type == srtc::MediaType::Audio) {
+            if (!isAudioCodec(codec.codec)) {
+                return { srtc::Error::Code::InvalidData, "An audio media can only have audio codecs" };
+            }
+        } else if (mediaItem.media_type == srtc::MediaType::Video) {
+            if (!isVideoCodec(codec.codec)) {
+                return { srtc::Error::Code::InvalidData, "A video media can only have video codecs" };
+            }
+        }
+    }
+
+    return srtc::Error::OK;
+}
+
 } // namespace
 
 namespace srtc
@@ -50,10 +72,8 @@ PeerConnection::~PeerConnection()
     close();
 }
 
-std::pair<std::shared_ptr<SdpOffer>, Error> PeerConnection::createPublishOffer(
-    const PubOfferConfig& pubConfig,
-    const std::optional<PubVideoConfig>& videoConfig,
-    const std::optional<PubAudioConfig>& audioConfig)
+std::pair<std::shared_ptr<SdpOffer>, Error> PeerConnection::createPublishOffer(const PubOfferConfig& pubConfig,
+                                                                               const PubMediaConfig& mediaConfig)
 {
     if (mDirection != Direction::Publish) {
         return { {}, { Error::Code::InvalidData, "The peer connection's direction is not publish" } };
@@ -67,37 +87,39 @@ std::pair<std::shared_ptr<SdpOffer>, Error> PeerConnection::createPublishOffer(
     config.enable_rfc8851 = pubConfig.enable_rfc8851;
     config.debug_drop_packets = pubConfig.debug_drop_packets;
 
-    std::optional<SdpOffer::VideoConfig> video;
-    if (videoConfig) {
-        video = SdpOffer::VideoConfig{};
+    std::vector<SdpOffer::MediaLine> media;
 
-        for (const auto& codec : videoConfig->codec_list) {
-            video->codec_list.emplace_back(codec.codec, codec.profile_level_id);
+    for (const auto& pubMediaItem : mediaConfig.media_list) {
+        media.emplace_back();
+        auto& mediaLine = media.back();
+
+        if (const auto error = validateMediaItem(pubMediaItem); error.isError()) {
+            return { {}, error };
         }
-        for (const auto& layer : videoConfig->simulcast_layer_list) {
-            const srtc::SimulcastLayer simulcastLayer = {
-                layer.name, layer.width, layer.height, layer.frames_per_second, layer.kilobits_per_second
-            };
-            video->simulcast_layer_list.push_back(simulcastLayer);
+
+        mediaLine.id = pubMediaItem.media_id;
+        mediaLine.mediaType = pubMediaItem.media_type;
+
+        for (const auto& codec : pubMediaItem.codec_list) {
+            mediaLine.codec_list.emplace_back(codec.codec, codec.profile_level_id, codec.minptime, codec.stereo);
+        }
+
+        for (const auto& layer : pubMediaItem.layer_list) {
+            mediaLine.layer_list.emplace_back();
+            auto& outLayer = mediaLine.layer_list.back();
+            outLayer.name = layer.name;
+            outLayer.width = layer.width;
+            outLayer.height = layer.height;
+            outLayer.frames_per_second = layer.frames_per_second;
+            outLayer.kilobits_per_second = layer.kilobits_per_second;
         }
     }
 
-    std::optional<SdpOffer::AudioConfig> audio;
-    if (audioConfig) {
-        audio = SdpOffer::AudioConfig{};
-
-        for (const auto& codec : audioConfig->codec_list) {
-            audio->codec_list.emplace_back(codec.codec, codec.minptime, codec.stereo);
-        }
-    }
-
-    return { std::shared_ptr<SdpOffer>(new SdpOffer(Direction::Publish, config, video, audio)), Error::OK };
+    return { std::shared_ptr<SdpOffer>(new SdpOffer(Direction::Publish, config, media)), Error::OK };
 }
 
-std::pair<std::shared_ptr<SdpOffer>, Error> PeerConnection::createSubscribeOffer(
-    const SubOfferConfig& subConfig,
-    const std::optional<SubVideoConfig>& videoConfig,
-    const std::optional<SubAudioConfig>& audioConfig)
+std::pair<std::shared_ptr<SdpOffer>, Error> PeerConnection::createSubscribeOffer(const SubOfferConfig& subConfig,
+                                                                                 const SubMediaConfig& mediaConfig)
 {
     if (mDirection != Direction::Subscribe) {
         return { {}, { Error::Code::InvalidData, "The peer connection's direction is not subscribe" } };
@@ -111,25 +133,25 @@ std::pair<std::shared_ptr<SdpOffer>, Error> PeerConnection::createSubscribeOffer
     config.jitter_buffer_nack_delay_millis = subConfig.jitter_buffer_nack_delay_millis;
     config.debug_drop_packets = subConfig.debug_drop_packets;
 
-    std::optional<SdpOffer::VideoConfig> video;
-    if (videoConfig) {
-        video = SdpOffer::VideoConfig{};
+    std::vector<SdpOffer::MediaLine> media;
 
-        for (const auto& codec : videoConfig->codec_list) {
-            video->codec_list.emplace_back(codec.codec, codec.profile_level_id);
+    for (const auto& pubMediaItem : mediaConfig.media_list) {
+        media.emplace_back();
+        auto& mediaLine = media.back();
+
+        if (const auto error = validateMediaItem(pubMediaItem); error.isError()) {
+            return { {}, error };
+        }
+
+        mediaLine.id = pubMediaItem.media_id;
+        mediaLine.mediaType = pubMediaItem.media_type;
+
+        for (const auto& codec : pubMediaItem.codec_list) {
+            mediaLine.codec_list.emplace_back(codec.codec, codec.profile_level_id, codec.minptime, codec.stereo);
         }
     }
 
-    std::optional<SdpOffer::AudioConfig> audio;
-    if (audioConfig) {
-        audio = SdpOffer::AudioConfig{};
-
-        for (const auto& codec : audioConfig->codec_list) {
-            audio->codec_list.emplace_back(codec.codec, codec.minptime, codec.stereo);
-        }
-    }
-
-    return { std::shared_ptr<SdpOffer>(new SdpOffer(Direction::Subscribe, config, video, audio)), Error::OK };
+    return { std::shared_ptr<SdpOffer>(new SdpOffer(Direction::Subscribe, config, media)), Error::OK };
 }
 
 Error PeerConnection::setOffer(const std::shared_ptr<SdpOffer>& offer)
@@ -183,22 +205,16 @@ Error PeerConnection::setAnswer(const std::shared_ptr<SdpAnswer>& answer)
 
     mSdpAnswer = answer;
 
-    mVideoSingleTrack = answer->getVideoSingleTrack();
-    mVideoSimulcastTrackList = answer->getVideoSimulcastTrackList();
-    mAudioTrack = answer->getAudioTrack();
-
-    mSendSimulcastLayerList.clear();
-    for (const auto& track : mVideoSimulcastTrackList) {
-        if (track->getMedia()->getType() == MediaType::Video && track->isSimulcast()) {
-            const auto layer = track->getSimulcastLayer();
-            assert(layer != nullptr);
-            mSendSimulcastLayerList.push_back(*layer);
-        }
-    }
-
     if (mSdpOffer && mSdpAnswer) {
         if (mSdpOffer->getDirection() != mSdpAnswer->getDirection()) {
             return { Error::Code::InvalidData, "Offer and answer must use same direction, publish or subscribe" };
+        }
+
+        for (const auto& media : answer->getMediaList()) {
+            mMediaEntryList.emplace_back(media);
+        }
+        for (const auto& track : answer->getTrackList()) {
+            mTrackEntryList.emplace_back(track);
         }
 
         mDataChannelsNegotiated = mSdpOffer->hasDataChannel() && mSdpAnswer->hasDataChannel();
@@ -208,47 +224,32 @@ Error PeerConnection::setAnswer(const std::shared_ptr<SdpAnswer>& answer)
 
         if (mDirection == Direction::Publish) {
             // Packetizers
-            if (mVideoSingleTrack) {
-                const auto [packetizer, error] = Packetizer::make(mVideoSingleTrack);
+            for (auto& entry : mTrackEntryList) {
+                const auto [packetizer, error] = Packetizer::make(entry.track);
                 if (error.isError()) {
                     return error;
                 }
-                mVideoSinglePacketizer = packetizer;
-            } else if (!mVideoSimulcastTrackList.empty()) {
-                for (const auto& track : mVideoSimulcastTrackList) {
-                    const auto simulcastLayer = track->getSimulcastLayer();
-
-                    const auto [packetizer, error] = Packetizer::make(track);
-                    if (error.isError()) {
-                        return error;
-                    }
-
-                    mVideoSimulcastLayerList.emplace_back(simulcastLayer->name, track, packetizer);
-                }
+                entry.packetizer = packetizer;
             }
 
-            if (mAudioTrack) {
-                const auto [packetizer, error] = Packetizer::make(mAudioTrack);
-                if (error.isError()) {
-                    return error;
+            // Simulcast layers
+            for (auto& mediaEntry : mMediaEntryList) {
+                if (mediaEntry.media->getType() == MediaType::Video) {
+                    for (const auto& trackEntry : mTrackEntryList) {
+                        if (trackEntry.track->getMedia() == mediaEntry.media && trackEntry.track->isSimulcast()) {
+                            mediaEntry.layerList.push_back(*trackEntry.track->getSimulcastLayer());
+                        }
+                    }
                 }
-                mAudioPacketizer = packetizer;
             }
         } else if (mDirection == Direction::Subscribe) {
             // Jitter buffers are created when we connect because we have to know the rtt
-            if (mVideoSingleTrack) {
-                const auto [depacketizer, error] = Depacketizer::make(mVideoSingleTrack);
+            for (auto& entry : mTrackEntryList) {
+                const auto [depacketizer, error] = Depacketizer::make(entry.track);
                 if (error.isError()) {
                     return error;
                 }
-                mVideoDepacketizer = depacketizer;
-            }
-            if (mAudioTrack) {
-                const auto [depacketizer, error] = Depacketizer::make(mAudioTrack);
-                if (error.isError()) {
-                    return error;
-                }
-                mAudioDepacketizer = depacketizer;
+                entry.depacketizer = depacketizer;
             }
         }
 
@@ -274,19 +275,30 @@ std::shared_ptr<SdpAnswer> PeerConnection::getAnswer() const
     return mSdpAnswer;
 }
 
-std::shared_ptr<Track> PeerConnection::getVideoSingleTrack() const
+std::vector<std::shared_ptr<Media>> PeerConnection::getMediaList() const
 {
-    return mVideoSingleTrack;
+    std::vector<std::shared_ptr<Media>> list;
+
+    std::lock_guard lock(mMutex);
+
+    for (const auto& entry : mMediaEntryList) {
+        list.push_back(entry.media);
+    }
+
+    return list;
 }
 
-std::vector<std::shared_ptr<Track>> PeerConnection::getVideoSimulcastTrackList() const
+std::vector<std::shared_ptr<Track>> PeerConnection::getTrackList() const
 {
-    return mVideoSimulcastTrackList;
-}
+    std::vector<std::shared_ptr<Track>> list;
 
-std::shared_ptr<Track> PeerConnection::getAudioTrack() const
-{
-    return mAudioTrack;
+    std::lock_guard lock(mMutex);
+
+    for (const auto& entry : mTrackEntryList) {
+        list.push_back(entry.track);
+    }
+
+    return list;
 }
 
 void PeerConnection::setConnectionStateListener(const ConnectionStateListener& listener)
@@ -307,28 +319,7 @@ void PeerConnection::setPublishKeyFrameRequestedListener(const PublishKeyFrameRe
     mPublishKeyFrameRequestedListener = listener;
 }
 
-Error PeerConnection::setVideoSingleCodecSpecificData(std::vector<ByteBuffer>&& list)
-{
-    std::lock_guard lock(mMutex);
-
-    if (mDirection != Direction::Publish) {
-        return { Error::Code::InvalidData, "The peer connection's direction is not publish" };
-    }
-
-    if (mVideoSingleTrack == nullptr) {
-        return { Error::Code::InvalidData, "There is no video track" };
-    }
-    if (mVideoSinglePacketizer == nullptr) {
-        return { Error::Code::InvalidData, "There is no video packetizer" };
-    }
-
-    mFrameSendQueue.push_back({ 0, mVideoSingleTrack, mVideoSinglePacketizer, {}, std::move(list) });
-    mEventLoop->interrupt();
-
-    return Error::OK;
-}
-
-Error PeerConnection::publishVideoSingleFrame(int64_t pts_usec, ByteBuffer&& buf)
+Error PeerConnection::setVideoCodecSpecificData(const std::shared_ptr<Track>& track, std::vector<ByteBuffer>&& list)
 {
     if (mDirection != Direction::Publish) {
         return { Error::Code::InvalidData, "The peer connection's direction is not publish" };
@@ -340,54 +331,19 @@ Error PeerConnection::publishVideoSingleFrame(int64_t pts_usec, ByteBuffer&& buf
         return Error::OK;
     }
 
-    if (mVideoSingleTrack == nullptr) {
-        return { Error::Code::InvalidData, "There is no video track" };
-    }
-    if (mVideoSinglePacketizer == nullptr) {
-        return { Error::Code::InvalidData, "There is no video packetizer" };
+    for (const auto& entry : mTrackEntryList) {
+        if (entry.track == track) {
+            mFrameSendQueue.push_back({ 0, track, entry.packetizer, {}, std::move(list) });
+            mEventLoop->interrupt();
+
+            return Error::OK;
+        }
     }
 
-    mFrameSendQueue.push_back({ pts_usec, mVideoSingleTrack, mVideoSinglePacketizer, std::move(buf) });
-    mEventLoop->interrupt();
-
-    return Error::OK;
+    return { Error::Code::InvalidData, "The track is not found" };
 }
 
-Error PeerConnection::setVideoSimulcastCodecSpecificData(const std::string& layerName, std::vector<ByteBuffer>&& list)
-{
-    if (mDirection != Direction::Publish) {
-        return { Error::Code::InvalidData, "The peer connection's direction is not publish" };
-    }
-
-    std::lock_guard lock(mMutex);
-
-    const auto iter = std::find_if(mVideoSimulcastLayerList.begin(),
-                                   mVideoSimulcastLayerList.end(),
-                                   [&layerName](const auto& layer) { return layer.ridName == layerName; });
-    if (iter == mVideoSimulcastLayerList.end()) {
-        return { Error::Code::InvalidData, "There is no video layer named " + layerName };
-    }
-
-    const auto& layer = *iter;
-    if (layer.track == nullptr) {
-        return { Error::Code::InvalidData, "There is no video track" };
-    }
-    if (layer.packetizer == nullptr) {
-        return { Error::Code::InvalidData, "There is no video packetizer" };
-    }
-
-    FrameToSend frameToSend = {};
-    frameToSend.track = layer.track;
-    frameToSend.packetizer = layer.packetizer;
-    frameToSend.csd = std::move(list);
-
-    mFrameSendQueue.push_back(std::move(frameToSend));
-    mEventLoop->interrupt();
-
-    return Error::OK;
-}
-
-Error PeerConnection::publishVideoSimulcastFrame(int64_t pts_usec, const std::string& layerName, ByteBuffer&& buf)
+Error PeerConnection::publishVideoFrame(const std::shared_ptr<Track>& track, int64_t pts_usec, ByteBuffer&& buf)
 {
     if (mDirection != Direction::Publish) {
         return { Error::Code::InvalidData, "The peer connection's direction is not publish" };
@@ -399,34 +355,62 @@ Error PeerConnection::publishVideoSimulcastFrame(int64_t pts_usec, const std::st
         return Error::OK;
     }
 
-    const auto iter = std::find_if(mVideoSimulcastLayerList.begin(),
-                                   mVideoSimulcastLayerList.end(),
-                                   [&layerName](const auto& layer) { return layer.ridName == layerName; });
-    if (iter == mVideoSimulcastLayerList.end()) {
-        return { Error::Code::InvalidData, "There is no video layer named " + layerName };
+    for (const auto& entry : mTrackEntryList) {
+        if (entry.track == track) {
+            mFrameSendQueue.push_back({ pts_usec, track, entry.packetizer, std::move(buf) });
+            mEventLoop->interrupt();
+
+            return Error::OK;
+        }
     }
 
-    const auto& layer = *iter;
-    if (layer.track == nullptr) {
-        return { Error::Code::InvalidData, "There is no video track" };
-    }
-    if (layer.packetizer == nullptr) {
-        return { Error::Code::InvalidData, "There is no video packetizer" };
-    }
-
-    FrameToSend frameToSend = {};
-    frameToSend.pts_usec = pts_usec;
-    frameToSend.track = layer.track;
-    frameToSend.packetizer = layer.packetizer;
-    frameToSend.buf = std::move(buf);
-
-    mFrameSendQueue.push_back(std::move(frameToSend));
-    mEventLoop->interrupt();
-
-    return Error::OK;
+    return { Error::Code::InvalidData, "The track is not found" };
 }
 
-Error PeerConnection::updateVideoSimulcastLayer(const SimulcastLayer& updated)
+Error PeerConnection::updateVideoSimulcastLayer(const std::shared_ptr<Track>& track, const SimulcastLayer& updated)
+{
+    if (mDirection != Direction::Publish) {
+        return { Error::Code::InvalidData, "The peer connection's direction is not publish" };
+    }
+
+    const auto media = track->getMedia();
+    if (media->getType() != MediaType::Video) {
+        return { Error::Code::InvalidData, "The track media type is not video" };
+    }
+
+    if (!track->isSimulcast()) {
+        return { Error::Code::InvalidData, "The track is not simulcast" };
+    }
+
+    const auto layer = track->getSimulcastLayer();
+    if (layer->name != updated.name) {
+        return { Error::Code::InvalidData, "The track name does not match the layer name" };
+    }
+
+    std::lock_guard lock(mMutex);
+
+    if (mConnectionState != ConnectionState::Connected) {
+        return Error::OK;
+    }
+
+    for (const auto& entry : mTrackEntryList) {
+        if (entry.track == track) {
+            FrameToSend frameToSend = {};
+            frameToSend.track = track;
+            frameToSend.packetizer = entry.packetizer;
+            frameToSend.layer = updated;
+
+            mFrameSendQueue.push_back(std::move(frameToSend));
+            mEventLoop->interrupt();
+
+            return Error::OK;
+        }
+    }
+
+    return { Error::Code::InvalidData, "The track is not found" };
+}
+
+Error PeerConnection::publishAudioFrame(const std::shared_ptr<Track>& track, int64_t pts_usec, ByteBuffer&& buf)
 {
     if (mDirection != Direction::Publish) {
         return { Error::Code::InvalidData, "The peer connection's direction is not publish" };
@@ -438,56 +422,16 @@ Error PeerConnection::updateVideoSimulcastLayer(const SimulcastLayer& updated)
         return Error::OK;
     }
 
-    const auto iter =
-        std::find_if(mVideoSimulcastLayerList.begin(),
-                     mVideoSimulcastLayerList.end(),
-                     [layerName = updated.name](const auto& layer) { return layer.ridName == layerName; });
-    if (iter == mVideoSimulcastLayerList.end()) {
-        return { Error::Code::InvalidData, "There is no video layer named " + updated.name };
+    for (const auto& entry : mTrackEntryList) {
+        if (entry.track == track) {
+            mFrameSendQueue.push_back({ pts_usec, track, entry.packetizer, std::move(buf) });
+            mEventLoop->interrupt();
+
+            return Error::OK;
+        }
     }
 
-    const auto& layer = *iter;
-    if (layer.track == nullptr) {
-        return { Error::Code::InvalidData, "There is no video track" };
-    }
-    if (layer.packetizer == nullptr) {
-        return { Error::Code::InvalidData, "There is no video packetizer" };
-    }
-
-    FrameToSend frameToSend = {};
-    frameToSend.track = layer.track;
-    frameToSend.packetizer = layer.packetizer;
-    frameToSend.layer = updated;
-
-    mFrameSendQueue.push_back(std::move(frameToSend));
-    mEventLoop->interrupt();
-
-    return Error::OK;
-}
-
-Error PeerConnection::publishAudioFrame(int64_t pts_usec, ByteBuffer&& buf)
-{
-    if (mDirection != Direction::Publish) {
-        return { Error::Code::InvalidData, "The peer connection's direction is not publish" };
-    }
-
-    std::lock_guard lock(mMutex);
-
-    if (mConnectionState != ConnectionState::Connected) {
-        return Error::OK;
-    }
-
-    if (mAudioTrack == nullptr) {
-        return { Error::Code::InvalidData, "There is no audio track" };
-    }
-    if (mAudioPacketizer == nullptr) {
-        return { Error::Code::InvalidData, "There is no audio packetizer" };
-    }
-
-    mFrameSendQueue.push_back({ pts_usec, mAudioTrack, mAudioPacketizer, std::move(buf) });
-    mEventLoop->interrupt();
-
-    return Error::OK;
+    return { Error::Code::InvalidData, "The track is not found" };
 }
 
 void PeerConnection::setSubscribeConnectionStatsListener(const SubscribeConnectionStatsListener& listener)
@@ -594,16 +538,13 @@ void PeerConnection::networkThreadWorkerFunc()
                 timeout = selectedTimeout;
             }
         }
-        if (mJitterBufferVideo) {
-            if (const auto jitterTimeout = mJitterBufferVideo->getTimeoutMillis(kDefaultTimeoutMillis);
-                timeout > jitterTimeout) {
-                timeout = jitterTimeout;
-            }
-        }
-        if (mJitterBufferAudio) {
-            if (const auto jitterTimeout = mJitterBufferAudio->getTimeoutMillis(kDefaultTimeoutMillis);
-                timeout > jitterTimeout) {
-                timeout = jitterTimeout;
+
+        for (const auto& trackEntry : mTrackEntryList) {
+            if (trackEntry.jitterBuffer) {
+                if (const auto jitterTimeout = trackEntry.jitterBuffer->getTimeoutMillis(kDefaultTimeoutMillis);
+                    timeout > jitterTimeout) {
+                    timeout = jitterTimeout;
+                }
             }
         }
 
@@ -645,19 +586,25 @@ void PeerConnection::networkThreadWorkerFunc()
             // Update simulcast layer
             if (item.layer.has_value()) {
                 const auto updated = item.layer.value();
-                for (auto& layer : mSendSimulcastLayerList) {
-                    if (layer.name == updated.name) {
-                        layer.width = updated.width;
-                        layer.height = updated.height;
-                        layer.frames_per_second = updated.frames_per_second;
-                        layer.kilobits_per_second = updated.kilobits_per_second;
-                        break;
+                const auto media = item.track->getMedia();
+
+                for (auto& mediaEntry : mMediaEntryList) {
+                    if (mediaEntry.media == media) {
+                        for (auto& layer : mediaEntry.layerList) {
+                            if (layer.name == updated.name) {
+                                layer.width = updated.width;
+                                layer.height = updated.height;
+                                layer.frames_per_second = updated.frames_per_second;
+                                layer.kilobits_per_second = updated.kilobits_per_second;
+                                break;
+                            }
+                        }
                     }
                 }
             }
 
             // Frames to send
-            if (mSelectedCandidate) {
+            if (mSelectedCandidate && (!item.buf.empty() || !item.csd.empty())) {
                 mSelectedCandidate->addSendFrame(PeerCandidate::FrameToSend{
                     item.pts_usec, item.track, item.packetizer, std::move(item.buf), std::move(item.csd) });
             }
@@ -683,11 +630,10 @@ void PeerConnection::networkThreadWorkerFunc()
         }
 
         // Jitter buffer processing
-        if (const auto buffer = mJitterBufferVideo) {
-            processJitterBuffer(buffer);
-        }
-        if (const auto buffer = mJitterBufferAudio) {
-            processJitterBuffer(buffer);
+        for (const auto& trackEntry : mTrackEntryList) {
+            if (trackEntry.jitterBuffer) {
+                processJitterBuffer(trackEntry.jitterBuffer);
+            }
         }
     }
 
@@ -696,8 +642,9 @@ void PeerConnection::networkThreadWorkerFunc()
     // Clear everything on this thread before exiting
     mConnectingCandidateList.clear();
     mSelectedCandidate.reset();
-    mJitterBufferVideo.reset();
-    mJitterBufferAudio.reset();
+
+    mMediaEntryList.clear();
+    mTrackEntryList.clear();
 
     // We are all done
     setConnectionState(ConnectionState::Closed);
@@ -822,14 +769,8 @@ std::vector<std::shared_ptr<Track>> PeerConnection::collectTracks() const
 {
     std::vector<std::shared_ptr<Track>> list;
 
-    if (const auto track = mVideoSingleTrack) {
-        list.push_back(track);
-    }
-    for (const auto& item : mVideoSimulcastTrackList) {
-        list.push_back(item);
-    }
-    if (const auto track = mAudioTrack) {
-        list.push_back(track);
+    for (const auto& trackEntry : mTrackEntryList) {
+        list.push_back(trackEntry.track);
     }
 
     return list;
@@ -845,8 +786,11 @@ void PeerConnection::onCandidateConnecting(PeerCandidate* candidate)
 {
     setConnectionState(ConnectionState::Connecting);
 
-    mJitterBufferVideo.reset();
-    mJitterBufferAudio.reset();
+    for (auto& trackEntry : mTrackEntryList) {
+        if (trackEntry.jitterBuffer) {
+            trackEntry.jitterBuffer.reset();
+        }
+    }
 }
 
 void PeerConnection::onCandidateIceConnected(PeerCandidate* candidate)
@@ -883,7 +827,7 @@ void PeerConnection::onCandidateDtlsConnected(PeerCandidate* candidate)
 {
     setConnectionState(ConnectionState::Connected);
 
-    if (mDirection == Direction::Subscribe && !mJitterBufferVideo && !mJitterBufferAudio) {
+    if (mDirection == Direction::Subscribe) {
         // We should have the rtt from ice
         const auto rtt = candidate->getIceRtt();
         assert(rtt.has_value());
@@ -918,19 +862,10 @@ void PeerConnection::onCandidateDtlsConnected(PeerCandidate* candidate)
             }
         }
 
-        if (const auto track = mVideoSingleTrack) {
-            assert(mVideoDepacketizer);
-            mVideoDepacketizer->reset();
-
-            mJitterBufferVideo =
-                std::make_shared<JitterBuffer>(track, mVideoDepacketizer, kJitterBufferSize, length, nackDelay);
-        }
-        if (const auto track = mAudioTrack) {
-            assert(mAudioDepacketizer);
-            mAudioDepacketizer->reset();
-
-            mJitterBufferAudio =
-                std::make_shared<JitterBuffer>(track, mAudioDepacketizer, kJitterBufferSize, length, nackDelay);
+        for (auto trackEntry : mTrackEntryList) {
+            trackEntry.depacketizer->reset();
+            trackEntry.jitterBuffer = std::make_shared<JitterBuffer>(
+                trackEntry.track, trackEntry.depacketizer, kJitterBufferSize, length, nackDelay);
         }
     }
 
@@ -970,33 +905,15 @@ void PeerConnection::onCandidateFailedToConnect(PeerCandidate* candidate, const 
 
 void PeerConnection::onCandidateReceivedMediaPacket(PeerCandidate* candiate, const std::shared_ptr<RtpPacket>& packet)
 {
-#ifdef NDEBUG
-#else
-    {
-        std::lock_guard lock(mMutex);
-        if (packet->getSSRC() == mSdpAnswer->getVideoSingleTrack()->getRtxSSRC()) {
-            ByteReader reader(packet->getPayload());
-            const auto seq = reader.remaining() >= 2 ? reader.readU16() : 0;
-            LOG(SRTC_LOG_V, "Received packet from RTX, SEQ = %u", seq);
-        }
-    }
-#endif
-
     if (mDirection == Direction::Subscribe) {
         const auto track = packet->getTrack();
 
         const auto stats = track->getStats();
         stats->setHighestReceivedSeq(packet->getSequence());
 
-        if (mVideoSingleTrack == track) {
-            if (const auto buffer = mJitterBufferVideo) {
-                assert(buffer->getTrack() == track);
-                buffer->consume(packet);
-            }
-        } else if (mAudioTrack == track) {
-            if (const auto buffer = mJitterBufferAudio) {
-                assert(buffer->getTrack() == track);
-                buffer->consume(packet);
+        for (const auto& trackEntry : mTrackEntryList) {
+            if (trackEntry.track == track) {
+                trackEntry.jitterBuffer->consume(packet);
             }
         }
     }
@@ -1022,9 +939,17 @@ void PeerConnection::onCandidateReceivedKeyFrameRequest(PeerCandidate* candiate)
     }
 }
 
-const std::vector<SimulcastLayer>& PeerConnection::getSimulcastLayerList() const
+void PeerConnection::getSimulcastLayerList(const std::shared_ptr<Media>& media,
+                                           std::vector<SimulcastLayer>& layerList) const
 {
-    return mSendSimulcastLayerList;
+    layerList.clear();
+
+    for (const auto& mediaEntry : mMediaEntryList) {
+        if (mediaEntry.media == media) {
+            layerList.insert(layerList.end(), mediaEntry.layerList.begin(), mediaEntry.layerList.end());
+            break;
+        }
+    }
 }
 
 void PeerConnection::onSctpDataChannelOpen(const std::string& label)
@@ -1068,9 +993,8 @@ void PeerConnection::sendReports()
         std::lock_guard lock(mMutex);
 
         if (mConnectionState == ConnectionState::Connected) {
-            const auto trackList = collectTracks();
-            mSelectedCandidate->sendSenderReports(trackList);
-            mSelectedCandidate->sendReceiverReports(trackList);
+            mSelectedCandidate->sendSenderReports();
+            mSelectedCandidate->sendReceiverReports();
         }
     }
 }
@@ -1092,9 +1016,8 @@ void PeerConnection::sendConnectionStats()
             return;
         }
 
-        const auto trackList = collectTracks();
-
-        for (const auto& trackItem : trackList) {
+        for (const auto& trackEntry : mTrackEntryList) {
+            const auto trackItem = trackEntry.track;
             const auto stats = trackItem->getStats();
 
             if (trackItem->getDirection() == Direction::Publish) {
@@ -1135,8 +1058,6 @@ void PeerConnection::sendConnectionStats()
 void PeerConnection::sendPictureLossIndicator()
 {
     if (mDirection == Direction::Subscribe) {
-        std::vector<std::shared_ptr<Track>> trackList;
-
         {
             std::lock_guard lock(mMutex);
             const auto& config = mSdpOffer->getConfig();
@@ -1151,10 +1072,8 @@ void PeerConnection::sendPictureLossIndicator()
             }
         }
 
-        trackList = collectTracks();
-
-        if (mSelectedCandidate && !trackList.empty()) {
-            mSelectedCandidate->sendPictureLossIndicators(trackList);
+        if (mSelectedCandidate) {
+            mSelectedCandidate->sendPictureLossIndicators();
         }
     }
 }

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -164,6 +164,9 @@ Error PeerConnection::setOffer(const std::shared_ptr<SdpOffer>& offer)
 
     assert(!mIsQuit);
 
+    if (mSdpOffer) {
+        return { Error::Code::InvalidData, "Connection already has an SDP offer" };
+    }
     if (mIsStarted) {
         return { Error::Code::InvalidData, "Connection is already started" };
     }
@@ -201,6 +204,9 @@ Error PeerConnection::setAnswer(const std::shared_ptr<SdpAnswer>& answer)
 
     if (mIsStarted) {
         return { Error::Code::InvalidData, "Connection is already started" };
+    }
+    if (mSdpAnswer) {
+        return { Error::Code::InvalidData, "Connection already has an SDP answer" };
     }
 
     mSdpAnswer = answer;

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -85,7 +85,6 @@ std::pair<std::shared_ptr<SdpOffer>, Error> PeerConnection::createPublishOffer(c
     config.enable_rtx = pubConfig.enable_rtx;
     config.enable_bwe = pubConfig.enable_bwe;
     config.enable_rfc8851 = pubConfig.enable_rfc8851;
-    config.debug_drop_packets = pubConfig.debug_drop_packets;
 
     std::vector<SdpOffer::MediaLine> media;
 
@@ -131,7 +130,6 @@ std::pair<std::shared_ptr<SdpOffer>, Error> PeerConnection::createSubscribeOffer
     config.pli_interval_millis = subConfig.pli_interval_millis;
     config.jitter_buffer_length_millis = subConfig.jitter_buffer_length_millis;
     config.jitter_buffer_nack_delay_millis = subConfig.jitter_buffer_nack_delay_millis;
-    config.debug_drop_packets = subConfig.debug_drop_packets;
 
     std::vector<SdpOffer::MediaLine> media;
 
@@ -867,7 +865,7 @@ void PeerConnection::onCandidateDtlsConnected(PeerCandidate* candidate)
             }
         }
 
-        for (auto trackEntry : mTrackEntryList) {
+        for (auto& trackEntry : mTrackEntryList) {
             trackEntry.depacketizer->reset();
             trackEntry.jitterBuffer = std::make_shared<JitterBuffer>(
                 trackEntry.track, trackEntry.depacketizer, kJitterBufferSize, length, nackDelay);

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -5,6 +5,7 @@
 #include "srtc/ice_agent.h"
 #include "srtc/jitter_buffer.h"
 #include "srtc/logging.h"
+#include "srtc/media.h"
 #include "srtc/packetizer.h"
 #include "srtc/peer_candidate.h"
 #include "srtc/rtcp_packet_source.h"
@@ -188,7 +189,7 @@ Error PeerConnection::setAnswer(const std::shared_ptr<SdpAnswer>& answer)
 
     mSendSimulcastLayerList.clear();
     for (const auto& track : mVideoSimulcastTrackList) {
-        if (track->getMediaType() == MediaType::Video && track->isSimulcast()) {
+        if (track->getMedia()->getType() == MediaType::Video && track->isSimulcast()) {
             const auto layer = track->getSimulcastLayer();
             assert(layer != nullptr);
             mSendSimulcastLayerList.push_back(*layer);

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -704,10 +704,10 @@ void PeerConnection::startConnecting()
         }
     }
 
+    const auto maxHostSize = std::max(hostList4.size(), hostList6.size());
     auto connectDelay = 0;
-    for (size_t i = 0; i < std::max(hostList4.size(), hostList6.size()); i += 1) {
+    for (size_t i = 0; i < maxHostSize; i += 1) {
         if (i < hostList4.size()) {
-            const auto host = hostList4[i];
             const auto listener = static_cast<PeerCandidateListener*>(this);
             const auto candidate = std::make_shared<PeerCandidate>(listener,
                                                                    trackList,
@@ -715,13 +715,12 @@ void PeerConnection::startConnecting()
                                                                    mSdpAnswer,
                                                                    mDataChannelMaxMessageSize,
                                                                    mLoopScheduler,
-                                                                   host,
+                                                                   hostList4[i],
                                                                    mEventLoop,
                                                                    std::chrono::milliseconds(connectDelay));
             mConnectingCandidateList.push_back(candidate);
         }
         if (i < hostList6.size()) {
-            const auto host = hostList6[i];
             const auto listener = static_cast<PeerCandidateListener*>(this);
             const auto candidate = std::make_shared<PeerCandidate>(listener,
                                                                    trackList,
@@ -729,7 +728,7 @@ void PeerConnection::startConnecting()
                                                                    mSdpAnswer,
                                                                    mDataChannelMaxMessageSize,
                                                                    mLoopScheduler,
-                                                                   host,
+                                                                   hostList6[i],
                                                                    mEventLoop,
                                                                    std::chrono::milliseconds(connectDelay));
             mConnectingCandidateList.push_back(candidate);
@@ -806,8 +805,8 @@ void PeerConnection::onCandidateIceConnected(PeerCandidate* candidate)
 
     mLoopScheduler->dump();
 
-    const auto trackList = collectTracks();
-    for (const auto& trackItem : trackList) {
+    for (const auto& trackEntry : mTrackEntryList) {
+        const auto trackItem = trackEntry.track;
         trackItem->getStats()->clear();
 
         trackItem->getRtpPacketSource()->clear();

--- a/src/rtp_extension_source_simulcast.cpp
+++ b/src/rtp_extension_source_simulcast.cpp
@@ -3,6 +3,7 @@
 #include "srtc/media.h"
 #include "srtc/packetizer.h"
 #include "srtc/rtp_extension_builder.h"
+#include "srtc/rtp_std_extensions.h"
 #include "srtc/track.h"
 #include "srtc/track_stats.h"
 
@@ -11,102 +12,104 @@
 namespace srtc
 {
 
-RtpExtensionSourceSimulcast::RtpExtensionSourceSimulcast(uint8_t nVideoExtMediaId,
-														 uint8_t nVideoExtStreamId,
-														 uint8_t nVideoExtRepairedStreamId,
-														 uint8_t nVideoExtGoogleVLA)
-	: mVideoExtMediaId(nVideoExtMediaId)
-	, mVideoExtStreamId(nVideoExtStreamId)
-	, mVideoExtRepairedStreamId(nVideoExtRepairedStreamId)
-	, mVideoExtGoogleVLA(nVideoExtGoogleVLA)
-	, mIsExtensionsValid(mVideoExtMediaId > 0 && mVideoExtStreamId > 0 && mVideoExtGoogleVLA > 0)
+RtpExtensionSourceSimulcast::RtpExtensionSourceSimulcast()
+    : mCurExtMediaId(0)
+    , mCurExtStreamId(0)
+    , mCurExtGoogleVLA(0)
 {
 }
 
 RtpExtensionSourceSimulcast::~RtpExtensionSourceSimulcast() = default;
 
-std::shared_ptr<RtpExtensionSourceSimulcast> RtpExtensionSourceSimulcast::factory(bool isVideoSimulcast,
-																				  uint8_t nVideoExtMediaId,
-																				  uint8_t nVideoExtStreamId,
-																				  uint8_t nVideoExtRepairedStreamId,
-																				  uint8_t nVideoExtGoogleVLA)
+std::shared_ptr<RtpExtensionSourceSimulcast> RtpExtensionSourceSimulcast::factory(bool isVideoSimulcast)
 {
-	if (isVideoSimulcast) {
-		if (nVideoExtMediaId > 0 && nVideoExtStreamId > 0 && nVideoExtGoogleVLA > 0) {
-			return std::make_shared<RtpExtensionSourceSimulcast>(
-				nVideoExtMediaId, nVideoExtStreamId, nVideoExtRepairedStreamId, nVideoExtGoogleVLA);
-		}
-	}
+    if (isVideoSimulcast) {
+        return std::make_shared<RtpExtensionSourceSimulcast>();
+    }
 
-	return {};
+    return {};
 }
 
 bool RtpExtensionSourceSimulcast::shouldAdd(const std::shared_ptr<Track>& track,
-											const std::shared_ptr<Packetizer>& packetizer,
-											const ByteBuffer& frame)
+                                            const std::shared_ptr<Packetizer>& packetizer,
+                                            const ByteBuffer& frame)
 {
-	if (mIsExtensionsValid && track->isSimulcast()) {
-		const auto stats = track->getStats();
-		return stats->getSentPackets() < 100 || packetizer->isKeyFrame(frame);
-	}
-	return false;
+    if (track->isSimulcast()) {
+        const auto media = track->getMedia();
+        const auto& extensionMap = media->getExtensionMap();
+        mCurExtMediaId = extensionMap.findByName(RtpStandardExtensions::kExtSdesMid);
+        mCurExtStreamId = extensionMap.findByName(RtpStandardExtensions::kExtSdesRtpStreamId);
+        mCurExtGoogleVLA = extensionMap.findByName(RtpStandardExtensions::kExtGoogleVLA);
+
+        if (mCurExtMediaId > 0 && mCurExtStreamId > 0 && mCurExtGoogleVLA > 0) {
+            const auto stats = track->getStats();
+            return stats->getSentPackets() < 100 || packetizer->isKeyFrame(frame);
+        }
+    }
+    return false;
 }
 
 void RtpExtensionSourceSimulcast::prepare(const std::shared_ptr<Track>& track,
-										  const std::vector<SimulcastLayer>& layerList)
+                                          const std::vector<SimulcastLayer>& layerList)
 {
-	const auto layer = track->getSimulcastLayer();
+    const auto layer = track->getSimulcastLayer();
 
-	mCurMediaId = track->getMedia()->getId();
-	mCurLayerName = layer->name;
+    mCurMediaId = track->getMedia()->getId();
+    mCurLayerName = layer->name;
 
-	buildGoogleVLA(mCurGoogleVLA, layer->index, layerList);
+    buildGoogleVLA(mCurGoogleVLA, layer->index, layerList);
 }
 
 void RtpExtensionSourceSimulcast::clear()
 {
-	mCurMediaId.clear();
-	mCurLayerName.clear();
-	mCurGoogleVLA.resize(0);
+    mCurMediaId.clear();
+    mCurLayerName.clear();
+    mCurGoogleVLA.resize(0);
 }
 
 uint8_t RtpExtensionSourceSimulcast::getPadding([[maybe_unused]] const std::shared_ptr<Track>& track,
-												[[maybe_unused]] size_t remainingDataSize)
+                                                [[maybe_unused]] size_t remainingDataSize)
 {
-	return 0;
+    return 0;
 }
 
 bool RtpExtensionSourceSimulcast::wantsExtension(const std::shared_ptr<Track>& track,
-												 bool isKeyFrame,
-												 unsigned int packetNumber) const
+                                                 bool isKeyFrame,
+                                                 unsigned int packetNumber) const
 {
-	return !mCurGoogleVLA.empty();
+    return !mCurGoogleVLA.empty();
 }
 
 void RtpExtensionSourceSimulcast::addExtension(RtpExtensionBuilder& builder,
-											   const std::shared_ptr<Track>& track,
-											   bool isKeyFrame,
-											   unsigned int packetNumber)
+                                               const std::shared_ptr<Track>& track,
+                                               bool isKeyFrame,
+                                               unsigned int packetNumber)
 {
-	builder.addStringValue(mVideoExtMediaId, mCurMediaId);
-	builder.addStringValue(mVideoExtStreamId, mCurLayerName);
-	builder.addBinaryValue(mVideoExtGoogleVLA, mCurGoogleVLA);
+    builder.addStringValue(mCurExtMediaId, mCurMediaId);
+    builder.addStringValue(mCurExtStreamId, mCurLayerName);
+    builder.addBinaryValue(mCurExtGoogleVLA, mCurGoogleVLA);
 }
 
 void RtpExtensionSourceSimulcast::updateForRtx(RtpExtensionBuilder& builder, const std::shared_ptr<Track>& track) const
 {
-	const auto layer = track->getSimulcastLayer();
+    const auto media = track->getMedia();
+    const auto& extensionMap = media->getExtensionMap();
 
-	if (const auto id = mVideoExtMediaId; id != 0) {
-		if (!builder.contains(id)) {
-			builder.addStringValue(id, track->getMedia()->getId());
-		}
-	}
-	if (const auto id = mVideoExtRepairedStreamId; id != 0) {
-		if (!builder.contains(id)) {
-			builder.addStringValue(id, layer->name);
-		}
-	}
+    const auto extMediaId = extensionMap.findByName(RtpStandardExtensions::kExtSdesMid);
+    const auto extRepairedStreamId = extensionMap.findByName(RtpStandardExtensions::kExtSdesRtpRepairedStreamId);
+
+    const auto layer = track->getSimulcastLayer();
+
+    if (const auto id = extMediaId; id != 0) {
+        if (!builder.contains(id)) {
+            builder.addStringValue(id, track->getMedia()->getId());
+        }
+    }
+    if (const auto id = extRepairedStreamId; id != 0) {
+        if (!builder.contains(id)) {
+            builder.addStringValue(id, layer->name);
+        }
+    }
 }
 
 } // namespace srtc

--- a/src/rtp_extension_source_simulcast.cpp
+++ b/src/rtp_extension_source_simulcast.cpp
@@ -1,5 +1,6 @@
 #include "srtc/rtp_extension_source_simulcast.h"
 #include "srtc/logging.h"
+#include "srtc/media.h"
 #include "srtc/packetizer.h"
 #include "srtc/rtp_extension_builder.h"
 #include "srtc/track.h"
@@ -56,7 +57,7 @@ void RtpExtensionSourceSimulcast::prepare(const std::shared_ptr<Track>& track,
 {
 	const auto layer = track->getSimulcastLayer();
 
-	mCurMediaId = track->getMediaId();
+	mCurMediaId = track->getMedia()->getId();
 	mCurLayerName = layer->name;
 
 	buildGoogleVLA(mCurGoogleVLA, layer->index, layerList);
@@ -98,7 +99,7 @@ void RtpExtensionSourceSimulcast::updateForRtx(RtpExtensionBuilder& builder, con
 
 	if (const auto id = mVideoExtMediaId; id != 0) {
 		if (!builder.contains(id)) {
-			builder.addStringValue(id, track->getMediaId());
+			builder.addStringValue(id, track->getMedia()->getId());
 		}
 	}
 	if (const auto id = mVideoExtRepairedStreamId; id != 0) {

--- a/src/rtp_extension_source_twcc.cpp
+++ b/src/rtp_extension_source_twcc.cpp
@@ -78,7 +78,7 @@ uint8_t RtpExtensionSourceTWCC::getPadding(const std::shared_ptr<Track>& track, 
             return 50;
         }
 
-        const auto type = track->getMedia()->getType();
+        const auto type = track->getMediaType();
         if (type == MediaType::Video) {
             // Video gets packetized, we can always add 10% to outgoing packets
             mProbingPacketCount += 1;

--- a/src/rtp_extension_source_twcc.cpp
+++ b/src/rtp_extension_source_twcc.cpp
@@ -21,11 +21,6 @@
 namespace
 {
 
-uint8_t findTWCCExtension(const srtc::ExtensionMap& map)
-{
-    return map.findByName(srtc::RtpStandardExtensions::kExtGoogleTWCC);
-}
-
 bool isReceivedWithTime(uint8_t status)
 {
     return status == srtc::twcc::kSTATUS_RECEIVED_SMALL_DELTA || status == srtc::twcc::kSTATUS_RECEIVED_LARGE_DELTA;
@@ -40,12 +35,8 @@ constexpr std::chrono::milliseconds kProbeDuration = std::chrono::milliseconds(1
 namespace srtc
 {
 
-RtpExtensionSourceTWCC::RtpExtensionSourceTWCC(uint8_t nVideoExtTWCC,
-                                               uint8_t nAudioExtTWCC,
-                                               const std::shared_ptr<RealScheduler>& scheduler)
-    : mVideoExtTWCC(nVideoExtTWCC)
-    , mAudioExtTWCC(nAudioExtTWCC)
-    , mNextPacketSEQ(1)
+RtpExtensionSourceTWCC::RtpExtensionSourceTWCC(const std::shared_ptr<RealScheduler>& scheduler)
+    : mNextPacketSEQ(1)
     , mPacketHistory(std::make_unique<twcc::PublishPacketHistory>())
     , mIsConnected(false)
     , mIsProbing(false)
@@ -69,21 +60,7 @@ std::shared_ptr<RtpExtensionSourceTWCC> RtpExtensionSourceTWCC::factory(const st
         return {};
     }
 
-    uint8_t nVideoExtTWCC = 0;
-    if (answer->hasVideoMedia()) {
-        nVideoExtTWCC = findTWCCExtension(answer->getVideoExtensionMap());
-    }
-
-    uint8_t nAudioExtTWCC = 0;
-    if (answer->hasAudioMedia()) {
-        nAudioExtTWCC = findTWCCExtension(answer->getAudioExtensionMap());
-    }
-
-    if (nVideoExtTWCC == 0 && nAudioExtTWCC == 0) {
-        return {};
-    }
-
-    return std::make_shared<RtpExtensionSourceTWCC>(nVideoExtTWCC, nAudioExtTWCC, scheduler);
+    return std::make_shared<RtpExtensionSourceTWCC>(scheduler);
 }
 
 void RtpExtensionSourceTWCC::onPeerConnected()
@@ -373,13 +350,9 @@ void RtpExtensionSourceTWCC::updatePublishConnectionStats(PublishConnectionStats
 
 uint8_t RtpExtensionSourceTWCC::getExtensionId(const std::shared_ptr<Track>& track) const
 {
-    const auto type = track->getMedia()->getType();
-    if (type == MediaType::Video) {
-        return mVideoExtTWCC;
-    } else if (type == MediaType::Audio) {
-        return mAudioExtTWCC;
-    }
-    return 0;
+    const auto media = track->getMedia();
+    const auto& extensionMap = media->getExtensionMap();
+    return extensionMap.findByName(RtpStandardExtensions::kExtGoogleTWCC);
 }
 
 void RtpExtensionSourceTWCC::onStartProbing()

--- a/src/rtp_extension_source_twcc.cpp
+++ b/src/rtp_extension_source_twcc.cpp
@@ -1,6 +1,7 @@
 #include "srtc/rtp_extension_source_twcc.h"
 #include "srtc/extension_map.h"
 #include "srtc/logging.h"
+#include "srtc/media.h"
 #include "srtc/rtp_extension_builder.h"
 #include "srtc/rtp_packet.h"
 #include "srtc/rtp_std_extensions.h"
@@ -100,12 +101,12 @@ uint8_t RtpExtensionSourceTWCC::getPadding(const std::shared_ptr<Track>& track, 
             return 50;
         }
 
-        const auto mediaType = track->getMediaType();
-        if (mediaType == MediaType::Video) {
+        const auto type = track->getMedia()->getType();
+        if (type == MediaType::Video) {
             // Video gets packetized, we can always add 10% to outgoing packets
             mProbingPacketCount += 1;
             return 120;
-        } else if (mediaType == MediaType::Audio) {
+        } else if (type == MediaType::Audio) {
             // Audio doesn't create split packets, we have to stay within the MTU
             if (remainingDataSize < 1060) {
                 mProbingPacketCount += 1;
@@ -372,10 +373,10 @@ void RtpExtensionSourceTWCC::updatePublishConnectionStats(PublishConnectionStats
 
 uint8_t RtpExtensionSourceTWCC::getExtensionId(const std::shared_ptr<Track>& track) const
 {
-    const auto media = track->getMediaType();
-    if (media == MediaType::Video) {
+    const auto type = track->getMedia()->getType();
+    if (type == MediaType::Video) {
         return mVideoExtTWCC;
-    } else if (media == MediaType::Audio) {
+    } else if (type == MediaType::Audio) {
         return mAudioExtTWCC;
     }
     return 0;

--- a/src/rtp_responder_twcc.cpp
+++ b/src/rtp_responder_twcc.cpp
@@ -1,5 +1,6 @@
 #include "srtc/rtp_responder_twcc.h"
 #include "srtc/logging.h"
+#include "srtc/media.h"
 #include "srtc/rtcp_packet.h"
 #include "srtc/rtp_extension.h"
 #include "srtc/rtp_packet.h"
@@ -103,10 +104,10 @@ std::vector<std::shared_ptr<RtcpPacket>> RtpResponderTWCC::run(const std::shared
 
 uint8_t RtpResponderTWCC::getExtensionId(const std::shared_ptr<Track>& track) const
 {
-    const auto media = track->getMediaType();
-    if (media == MediaType::Video) {
+    const auto type = track->getMedia()->getType();
+    if (type == MediaType::Video) {
         return mVideoExtTWCC;
-    } else if (media == MediaType::Audio) {
+    } else if (type == MediaType::Audio) {
         return mAudioExtTWCC;
     }
     return 0;

--- a/src/rtp_responder_twcc.cpp
+++ b/src/rtp_responder_twcc.cpp
@@ -12,23 +12,11 @@
 
 #define LOG(level, ...) srtc::log(level, "TWCC", __VA_ARGS__)
 
-namespace
-{
-
-uint8_t findTWCCExtension(const srtc::ExtensionMap& map)
-{
-    return map.findByName(srtc::RtpStandardExtensions::kExtGoogleTWCC);
-}
-
-} // namespace
-
 namespace srtc
 {
 
-RtpResponderTWCC::RtpResponderTWCC(uint8_t nVideoExtTWCC, uint8_t nAudioExtTWCC)
+RtpResponderTWCC::RtpResponderTWCC()
     : mPacketHistory(std::make_unique<twcc::SubscribePacketHistory>(getStableTimeMicros()))
-    , mVideoExtTWCC(nVideoExtTWCC)
-    , mAudioExtTWCC(nAudioExtTWCC)
 {
 }
 
@@ -41,23 +29,7 @@ std::shared_ptr<RtpResponderTWCC> RtpResponderTWCC::factory(const std::shared_pt
         return {};
     }
 
-    uint8_t nVideoExtTWCC = 0;
-    if (answer->hasVideoMedia()) {
-        nVideoExtTWCC = findTWCCExtension(answer->getVideoExtensionMap());
-        if (nVideoExtTWCC == 0) {
-            return {};
-        }
-    }
-
-    uint8_t nAudioExtTWCC = 0;
-    if (answer->hasAudioMedia()) {
-        nAudioExtTWCC = findTWCCExtension(answer->getAudioExtensionMap());
-        if (nAudioExtTWCC == 0) {
-            return {};
-        }
-    }
-
-    return std::make_shared<RtpResponderTWCC>(nVideoExtTWCC, nAudioExtTWCC);
+    return std::make_shared<RtpResponderTWCC>();
 }
 
 void RtpResponderTWCC::onMediaPacket(const std::shared_ptr<RtpPacket>& packet)
@@ -104,13 +76,10 @@ std::vector<std::shared_ptr<RtcpPacket>> RtpResponderTWCC::run(const std::shared
 
 uint8_t RtpResponderTWCC::getExtensionId(const std::shared_ptr<Track>& track) const
 {
-    const auto type = track->getMedia()->getType();
-    if (type == MediaType::Video) {
-        return mVideoExtTWCC;
-    } else if (type == MediaType::Audio) {
-        return mAudioExtTWCC;
-    }
-    return 0;
+    const auto media = track->getMedia();
+    const auto& extensionMap = media->getExtensionMap();
+
+    return extensionMap.findByName(RtpStandardExtensions::kExtGoogleTWCC);
 }
 
 } // namespace srtc

--- a/src/sdp_answer.cpp
+++ b/src/sdp_answer.cpp
@@ -22,7 +22,6 @@
 #endif
 
 #include <cassert>
-#include <cstring>
 
 namespace
 {
@@ -318,7 +317,7 @@ std::vector<std::shared_ptr<srtc::Track>> ParseMediaState::makeSimulcastTrackLis
     std::vector<std::shared_ptr<srtc::Track>> result;
 
     for (const auto& layer : layerList) {
-        const auto layerSsrc = offer->getVideoSimulastSSRC(layer.name);
+        const auto layerSsrc = offer->getVideoSimulastSSRC(mediaId, layer.name);
         const auto track = std::make_shared<srtc::Track>(singleTrack->getMedia(),
                                                          singleTrack->getDirection(),
                                                          layerSsrc.first,
@@ -662,8 +661,8 @@ Error SdpAnswerParser::parseLine_a(const std::string& tag,
         // a=simulcast recv low;mid;hi
         if (isInMediaSection && mediaState.mediaType.value() == MediaType::Video) {
             if (value == "recv" && props.size() == 1) {
-                const auto offerLayerList = offer->getVideoSimulcastLayerList();
-                if (offerLayerList.has_value()) {
+                const auto offerLayerList = offer->getVideoSimulcastLayerList(mediaState.mediaId);
+                if (offerLayerList.has_value() && !offerLayerList->empty()) {
                     const auto ridList = split_list(props[0]);
                     for (const auto& ridName : ridList) {
                         mediaState.addSimulcastLayer(offerLayerList.value(), ridName);
@@ -754,16 +753,11 @@ Error SdpAnswerParser::flush_m()
             return { Error::Code::InvalidData, "Media id cannot be empty" };
         }
 
-        const auto type = mediaState.mediaType.value();
-
         if (direction == Direction::Publish) {
-            if (type == MediaType::Video) {
-                mediaState.ssrc = offer->getVideoSSRC();
-                mediaState.rtxSsrc = offer->getRtxVideoSSRC();
-            } else if (type == MediaType::Audio) {
-                mediaState.ssrc = offer->getAudioSSRC();
-                mediaState.rtxSsrc = offer->getRtxAudioSSRC();
-            }
+            const auto publishSSRC = offer->getMediaSSRC(mediaState.mediaId);
+
+            mediaState.ssrc = publishSSRC.first;
+            mediaState.rtxSsrc = publishSSRC.second;
         }
 
         // Create media and track
@@ -852,52 +846,6 @@ std::vector<Host> SdpAnswer::getHostList() const
     return mHostList;
 }
 
-bool SdpAnswer::isVideoSimulcast() const
-{
-    return std::find_if(mTrackList.begin(), mTrackList.end(), [](const std::shared_ptr<Track>& track) {
-               return track->getMedia()->getType() == MediaType::Video && track->isSimulcast();
-           }) != mTrackList.end();
-}
-
-std::shared_ptr<Track> SdpAnswer::getVideoSingleTrack() const
-{
-    for (const auto& track : mTrackList) {
-        if (track->getMedia()->getType() == MediaType::Video) {
-            if (!track->isSimulcast()) {
-                return track;
-            }
-        }
-    }
-
-    return {};
-}
-
-std::vector<std::shared_ptr<Track>> SdpAnswer::getVideoSimulcastTrackList() const
-{
-    std::vector<std::shared_ptr<Track>> list;
-
-    for (const auto& track : mTrackList) {
-        if (track->getMedia()->getType() == MediaType::Video) {
-            if (track->isSimulcast()) {
-                list.push_back(track);
-            }
-        }
-    }
-
-    return list;
-}
-
-std::shared_ptr<Track> SdpAnswer::getAudioTrack() const
-{
-    for (const auto& track : mTrackList) {
-        if (track->getMedia()->getType() == MediaType::Audio) {
-            return track;
-        }
-    }
-
-    return {};
-}
-
 std::vector<std::shared_ptr<Media>> SdpAnswer::getMediaList() const
 {
     return mMediaList;
@@ -911,6 +859,13 @@ std::vector<std::shared_ptr<Track>> SdpAnswer::getTrackList() const
 bool SdpAnswer::isSetupActive() const
 {
     return mIsSetupActive;
+}
+
+bool SdpAnswer::isVideoSimulcast() const
+{
+    return std::any_of(mTrackList.begin(), mTrackList.end(), [](const std::shared_ptr<Track>& track) {
+        return track->getMediaType() == MediaType::Video && track->isSimulcast();
+    });
 }
 
 const X509Hash& SdpAnswer::getCertificateHash() const

--- a/src/sdp_answer.cpp
+++ b/src/sdp_answer.cpp
@@ -1,5 +1,6 @@
 #include "srtc/sdp_answer.h"
 #include "srtc/extension_map.h"
+#include "srtc/media.h"
 #include "srtc/sdp_offer.h"
 #include "srtc/track.h"
 #include "srtc/track_selector.h"
@@ -167,7 +168,6 @@ struct ParsePayloadState {
 };
 
 struct ParseMediaState {
-    std::optional<int> id;
     std::optional<srtc::MediaType> mediaType;
     srtc::ExtensionMap extensionMap;
     bool isSetupActive = { false };
@@ -238,11 +238,11 @@ ParsePayloadState* ParseMediaState::getPayloadState(uint8_t payloadId) const
 std::shared_ptr<srtc::Track> ParseMediaState::selectTrack(srtc::Direction direction,
                                                           const std::shared_ptr<srtc::TrackSelector>& selector) const
 {
-    if (!id.has_value()) {
-        return nullptr;
+    if (mediaId.empty()) {
+        return {};
     }
     if (!mediaType.has_value()) {
-        return nullptr;
+        return {};
     }
 
     auto ssrcMedia = ssrc;
@@ -256,6 +256,8 @@ std::shared_ptr<srtc::Track> ParseMediaState::selectTrack(srtc::Direction direct
         }
     }
 
+    const auto media = std::make_shared<srtc::Media>(mediaId, mediaType.value());
+
     std::vector<std::shared_ptr<srtc::Track>> list;
     for (size_t i = 0u; i < payloadStateSize; i += 1) {
         const auto& payloadState = payloadStateList[i];
@@ -263,10 +265,8 @@ std::shared_ptr<srtc::Track> ParseMediaState::selectTrack(srtc::Direction direct
             const auto trackSsrc = layerList.empty() ? ssrcMedia : 0;
             const auto trackRtxSsrc = layerList.empty() && payloadState.rtxPayloadId != 0 ? rtxSsrc : 0;
 
-            const auto track = std::make_shared<srtc::Track>(id.value(),
+            const auto track = std::make_shared<srtc::Track>(media,
                                                              direction,
-                                                             mediaType.value(),
-                                                             mediaId,
                                                              trackSsrc,
                                                              payloadState.payloadId,
                                                              trackRtxSsrc,
@@ -297,10 +297,8 @@ std::vector<std::shared_ptr<srtc::Track>> ParseMediaState::makeSimulcastTrackLis
 
     for (const auto& layer : layerList) {
         const auto layerSsrc = offer->getVideoSimulastSSRC(layer.name);
-        const auto track = std::make_shared<srtc::Track>(id.value(),
-                                                         offer->getDirection(),
-                                                         mediaType.value(),
-                                                         mediaId,
+        const auto track = std::make_shared<srtc::Track>(singleTrack->getMedia(),
+                                                         singleTrack->getDirection(),
                                                          layerSsrc.first,
                                                          singleTrack->getPayloadId(),
                                                          layerSsrc.second,
@@ -351,11 +349,11 @@ private:
     ParseMediaState mediaStateVideo, mediaStateAudio;
     ParseMediaState* mediaStateCurr = nullptr;
 
-    bool mIsApplicationSection = false;
-    bool mHasDataChannel = false;
-    bool mDataChannelSetupActive = false;
-    uint16_t mSctpPort = 5000;
-    uint32_t mMaxMessageSize = 262144;
+    bool isApplicationSection = false;
+    bool hasDataChannel = false;
+    bool dataChannelSetupActive = false;
+    uint16_t sctpPort = 5000;
+    uint32_t maxSctpMessageSize = 262144;
 
     std::vector<Host> hostList;
 
@@ -400,7 +398,7 @@ std::pair<std::shared_ptr<SdpAnswer>, Error> SdpAnswerParser::parse(const std::s
         }
     }
 
-    const bool hasMediaSection = mediaStateVideo.id.has_value() || mediaStateAudio.id.has_value();
+    const bool hasMediaSection = mediaStateVideo.mediaType.has_value() || mediaStateAudio.mediaType.has_value();
     if (hasMediaSection && !isRtcpMux) {
         return { {}, { Error::Code::InvalidData, "The rtcp-mux extension is required" } };
     }
@@ -408,14 +406,14 @@ std::pair<std::shared_ptr<SdpAnswer>, Error> SdpAnswerParser::parse(const std::s
         return { {}, { Error::Code::InvalidData, "No hosts to connect to" } };
     }
 
-    if (!hasMediaSection && !mHasDataChannel) {
+    if (!hasMediaSection && !hasDataChannel) {
         return { {}, { Error::Code::InvalidData, "No media tracks or data channels" } };
     }
 
     auto videoSingleTrack = mediaStateVideo.selectTrack(direction, selector);
     const auto audioTrack = mediaStateAudio.selectTrack(direction, selector);
 
-    if (!videoSingleTrack && !audioTrack && !mHasDataChannel) {
+    if (!videoSingleTrack && !audioTrack && !hasDataChannel) {
         return { nullptr, { Error::Code::InvalidData, "No media tracks or data channels" } };
     }
 
@@ -425,21 +423,21 @@ std::pair<std::shared_ptr<SdpAnswer>, Error> SdpAnswerParser::parse(const std::s
         videoSingleTrack.reset();
     }
 
-    std::shared_ptr<SdpAnswer> sdpAnswer(new SdpAnswer(direction,
-                                                       iceUFrag,
-                                                       icePassword,
-                                                       hostList,
-                                                       videoSingleTrack,
-                                                       videoSimulcastTrackList,
-                                                       audioTrack,
-                                                       mediaStateVideo.extensionMap,
-                                                       mediaStateAudio.extensionMap,
-                                                       mediaStateVideo.isSetupActive || mediaStateAudio.isSetupActive ||
-                                                           mDataChannelSetupActive,
-                                                       { certHashAlg, certHashBin, certHashHex },
-                                                       mHasDataChannel,
-                                                       mSctpPort,
-                                                       mMaxMessageSize));
+    std::shared_ptr<SdpAnswer> sdpAnswer(
+        new SdpAnswer(direction,
+                      iceUFrag,
+                      icePassword,
+                      hostList,
+                      videoSingleTrack,
+                      videoSimulcastTrackList,
+                      audioTrack,
+                      mediaStateVideo.extensionMap,
+                      mediaStateAudio.extensionMap,
+                      mediaStateVideo.isSetupActive || mediaStateAudio.isSetupActive || dataChannelSetupActive,
+                      { certHashAlg, certHashBin, certHashHex },
+                      hasDataChannel,
+                      sctpPort,
+                      maxSctpMessageSize));
 
     return { sdpAnswer, Error::OK };
 }
@@ -471,14 +469,15 @@ Error SdpAnswerParser::parseLine_m(const std::string& tag,
                                    const std::string& value,
                                    const std::vector<std::string>& props)
 {
-    mIsApplicationSection = false;
+    isApplicationSection = false;
+    mediaStateCurr = nullptr;
 
     // "m=application 9 UDP/DTLS/SCTP webrtc-datachannel"
     if (key == "application") {
         mediaStateCurr = nullptr;
         if (props.size() >= 2 && props[1] == "UDP/DTLS/SCTP") {
-            mIsApplicationSection = true;
-            mHasDataChannel = true;
+            isApplicationSection = true;
+            hasDataChannel = true;
         }
         return Error::OK;
     }
@@ -497,10 +496,6 @@ Error SdpAnswerParser::parseLine_m(const std::string& tag,
     }
 
     if (mediaStateCurr) {
-        if (const auto id = parse_u32(props[0]); id.has_value()) {
-            mediaStateCurr->id = id.value();
-        }
-
         std::vector<uint8_t> payloadIdList;
         for (size_t i = 2u; i < props.size(); i += 1) {
             if (const auto payloadId = parse_u32(props[i]);
@@ -529,8 +524,8 @@ Error SdpAnswerParser::parseLine_a(const std::string& tag,
     } else if (key == "setup") {
         if (mediaStateCurr) {
             mediaStateCurr->isSetupActive = value == "active";
-        } else if (mIsApplicationSection) {
-            mDataChannelSetupActive = value == "active";
+        } else if (isApplicationSection) {
+            dataChannelSetupActive = value == "active";
         }
     } else if (key == "fingerprint") {
         if (props.size() == 1) {
@@ -728,15 +723,15 @@ Error SdpAnswerParser::parseLine_a(const std::string& tag,
             }
         }
     } else if (key == "sctp-port") {
-        if (mIsApplicationSection) {
+        if (isApplicationSection) {
             if (const auto port = parse_u32(value); port.has_value() && port > 0u && port <= 65535u) {
-                mSctpPort = static_cast<uint16_t>(port.value());
+                sctpPort = static_cast<uint16_t>(port.value());
             }
         }
     } else if (key == "max-message-size") {
-        if (mIsApplicationSection) {
+        if (isApplicationSection) {
             if (const auto size = parse_u32(value); size.has_value()) {
-                mMaxMessageSize = size.value();
+                maxSctpMessageSize = size.value();
             }
         }
     }

--- a/src/sdp_answer.cpp
+++ b/src/sdp_answer.cpp
@@ -169,9 +169,8 @@ struct ParsePayloadState {
 
 struct ParseMediaState {
     std::optional<srtc::MediaType> mediaType;
-    srtc::ExtensionMap extensionMap;
-    bool isSetupActive = { false };
     std::string mediaId;
+    srtc::ExtensionMap extensionMap;
     std::vector<std::string> ridList;
     std::vector<srtc::Track::SimulcastLayer> layerList;
 
@@ -182,18 +181,37 @@ struct ParseMediaState {
     uint32_t rtxSsrc = { 0u };
     std::vector<uint32_t> ssrcList;
 
+    void clear();
+
     void addSimulcastLayer(const std::vector<srtc::SimulcastLayer>& offerLayerList, const std::string& ridName);
 
     void setPayloadList(const std::vector<uint8_t>& list);
 
     [[nodiscard]] ParsePayloadState* getPayloadState(uint8_t payloadId) const;
 
+    [[nodiscard]] std::shared_ptr<srtc::Media> createMedia() const;
+
     [[nodiscard]] std::shared_ptr<srtc::Track> selectTrack(srtc::Direction direction,
+                                                           const std::shared_ptr<srtc::Media>& media,
                                                            const std::shared_ptr<srtc::TrackSelector>& selector) const;
 
     [[nodiscard]] std::vector<std::shared_ptr<srtc::Track>> makeSimulcastTrackList(
         const std::shared_ptr<srtc::SdpOffer>& offer, const std::shared_ptr<srtc::Track>& singleTrack) const;
 };
+
+void ParseMediaState::clear()
+{
+    mediaType.reset();
+    mediaId.clear();
+    extensionMap.clear();
+    ridList.clear();
+    layerList.clear();
+    payloadStateSize = 0;
+    payloadStateList.reset();
+    ssrc = 0;
+    rtxSsrc = 0;
+    ssrcList.clear();
+}
 
 void ParseMediaState::addSimulcastLayer(const std::vector<srtc::SimulcastLayer>& offerLayerList,
                                         const std::string& ridName)
@@ -235,7 +253,13 @@ ParsePayloadState* ParseMediaState::getPayloadState(uint8_t payloadId) const
     return nullptr;
 }
 
+std::shared_ptr<srtc::Media> ParseMediaState::createMedia() const
+{
+    return std::make_shared<srtc::Media>(mediaId, mediaType.value(), extensionMap);
+}
+
 std::shared_ptr<srtc::Track> ParseMediaState::selectTrack(srtc::Direction direction,
+                                                          const std::shared_ptr<srtc::Media>& media,
                                                           const std::shared_ptr<srtc::TrackSelector>& selector) const
 {
     if (mediaId.empty()) {
@@ -252,11 +276,9 @@ std::shared_ptr<srtc::Track> ParseMediaState::selectTrack(srtc::Direction direct
             ssrcMedia = ssrcList.front();
         }
         if (ssrcMedia <= 0) {
-            return nullptr;
+            return {};
         }
     }
-
-    const auto media = std::make_shared<srtc::Media>(mediaId, mediaType.value(), extensionMap);
 
     std::vector<std::shared_ptr<srtc::Track>> list;
     for (size_t i = 0u; i < payloadStateSize; i += 1) {
@@ -282,7 +304,7 @@ std::shared_ptr<srtc::Track> ParseMediaState::selectTrack(srtc::Direction direct
     }
 
     if (list.empty()) {
-        return nullptr;
+        return {};
     }
 
     const auto selected = selector == nullptr ? list[0] : selector->selectTrack(list);
@@ -319,13 +341,13 @@ std::vector<std::shared_ptr<srtc::Track>> ParseMediaState::makeSimulcastTrackLis
 
 namespace srtc
 {
+
 class SdpAnswerParser
 {
 public:
-    SdpAnswerParser(Direction direction, const std::shared_ptr<SdpOffer>& offer);
+    SdpAnswerParser(const std::shared_ptr<SdpOffer>& offer, const std::shared_ptr<TrackSelector>& selector);
 
-    std::pair<std::shared_ptr<SdpAnswer>, Error> parse(const std::string& answer,
-                                                       const std::shared_ptr<TrackSelector>& selector);
+    std::pair<std::shared_ptr<SdpAnswer>, Error> parse(const std::string& answer);
 
 private:
     Error parseLine(const std::string& line);
@@ -339,22 +361,28 @@ private:
                       const std::string& value,
                       const std::vector<std::string>& props);
 
-    Direction direction;
-    std::shared_ptr<SdpOffer> offer;
+    Error flush_m();
+
+    const std::shared_ptr<SdpOffer> offer;
+    const Direction direction;
+    const std::shared_ptr<TrackSelector> selector;
 
     std::string iceUFrag, icePassword;
 
     bool isRtcpMux = false;
+    bool isSetupActive = false;
 
-    ParseMediaState mediaStateVideo, mediaStateAudio;
-    ParseMediaState* mediaStateCurr = nullptr;
+    bool isInMediaSection = false;
+    bool hasMedia = false;
+    ParseMediaState mediaState;
 
-    bool isApplicationSection = false;
+    bool isInApplicationSection = false;
     bool hasDataChannel = false;
-    bool dataChannelSetupActive = false;
     uint16_t sctpPort = 5000;
     uint32_t maxSctpMessageSize = 262144;
 
+    std::vector<std::shared_ptr<Media>> mediaList;
+    std::vector<std::shared_ptr<Track>> trackList;
     std::vector<Host> hostList;
 
     std::string certHashAlg;
@@ -362,24 +390,14 @@ private:
     std::string certHashHex;
 };
 
-SdpAnswerParser::SdpAnswerParser(Direction direction, const std::shared_ptr<SdpOffer>& offer)
-    : direction(direction)
-    , offer(offer)
+SdpAnswerParser::SdpAnswerParser(const std::shared_ptr<SdpOffer>& offer, const std::shared_ptr<TrackSelector>& selector)
+    : offer(offer)
+    , direction(offer->getDirection())
+    , selector(selector)
 {
-    mediaStateVideo.mediaType = MediaType::Video;
-    mediaStateAudio.mediaType = MediaType::Audio;
-
-    if (direction == Direction::Publish) {
-        mediaStateVideo.ssrc = offer->getVideoSSRC();
-        mediaStateVideo.rtxSsrc = offer->getRtxVideoSSRC();
-
-        mediaStateAudio.ssrc = offer->getAudioSSRC();
-        mediaStateAudio.rtxSsrc = offer->getRtxAudioSSRC();
-    }
 }
 
-std::pair<std::shared_ptr<SdpAnswer>, Error> SdpAnswerParser::parse(const std::string& answer,
-                                                                    const std::shared_ptr<TrackSelector>& selector)
+std::pair<std::shared_ptr<SdpAnswer>, Error> SdpAnswerParser::parse(const std::string& answer)
 {
     std::stringstream ss(answer);
 
@@ -398,44 +416,32 @@ std::pair<std::shared_ptr<SdpAnswer>, Error> SdpAnswerParser::parse(const std::s
         }
     }
 
-    const bool hasMediaSection = mediaStateVideo.mediaType.has_value() || mediaStateAudio.mediaType.has_value();
-    if (hasMediaSection && !isRtcpMux) {
+    if (const auto error = flush_m(); error.isError()) {
+        return { {}, error };
+    }
+
+    if (hasMedia && !isRtcpMux) {
         return { {}, { Error::Code::InvalidData, "The rtcp-mux extension is required" } };
     }
     if (hostList.empty()) {
         return { {}, { Error::Code::InvalidData, "No hosts to connect to" } };
     }
 
-    if (!hasMediaSection && !hasDataChannel) {
+    if (!hasMedia && !hasDataChannel) {
         return { {}, { Error::Code::InvalidData, "No media tracks or data channels" } };
     }
 
-    auto videoSingleTrack = mediaStateVideo.selectTrack(direction, selector);
-    const auto audioTrack = mediaStateAudio.selectTrack(direction, selector);
-
-    if (!videoSingleTrack && !audioTrack && !hasDataChannel) {
-        return { nullptr, { Error::Code::InvalidData, "No media tracks or data channels" } };
-    }
-
-    std::vector<std::shared_ptr<Track>> videoSimulcastTrackList;
-    if (!mediaStateVideo.layerList.empty()) {
-        videoSimulcastTrackList = mediaStateVideo.makeSimulcastTrackList(offer, videoSingleTrack);
-        videoSingleTrack.reset();
-    }
-
-    std::shared_ptr<SdpAnswer> sdpAnswer(
-        new SdpAnswer(direction,
-                      iceUFrag,
-                      icePassword,
-                      hostList,
-                      videoSingleTrack,
-                      videoSimulcastTrackList,
-                      audioTrack,
-                      mediaStateVideo.isSetupActive || mediaStateAudio.isSetupActive || dataChannelSetupActive,
-                      { certHashAlg, certHashBin, certHashHex },
-                      hasDataChannel,
-                      sctpPort,
-                      maxSctpMessageSize));
+    std::shared_ptr<SdpAnswer> sdpAnswer(new SdpAnswer(direction,
+                                                       iceUFrag,
+                                                       icePassword,
+                                                       hostList,
+                                                       mediaList,
+                                                       trackList,
+                                                       isSetupActive,
+                                                       { certHashAlg, certHashBin, certHashHex },
+                                                       hasDataChannel,
+                                                       sctpPort,
+                                                       maxSctpMessageSize));
 
     return { sdpAnswer, Error::OK };
 }
@@ -467,14 +473,19 @@ Error SdpAnswerParser::parseLine_m(const std::string& tag,
                                    const std::string& value,
                                    const std::vector<std::string>& props)
 {
-    isApplicationSection = false;
-    mediaStateCurr = nullptr;
+    if (const auto error = flush_m(); error.isError()) {
+        return error;
+    }
+
+    mediaState.clear();
+
+    isInApplicationSection = false;
+    isInMediaSection = false;
 
     // "m=application 9 UDP/DTLS/SCTP webrtc-datachannel"
     if (key == "application") {
-        mediaStateCurr = nullptr;
         if (props.size() >= 2 && props[1] == "UDP/DTLS/SCTP") {
-            isApplicationSection = true;
+            isInApplicationSection = true;
             hasDataChannel = true;
         }
         return Error::OK;
@@ -485,15 +496,9 @@ Error SdpAnswerParser::parseLine_m(const std::string& tag,
         return { Error::Code::InvalidData, "Only SAVPF over DTLS is supported" };
     }
 
-    if (key == "video") {
-        mediaStateCurr = &mediaStateVideo;
-    } else if (key == "audio") {
-        mediaStateCurr = &mediaStateAudio;
-    } else {
-        mediaStateCurr = nullptr;
-    }
+    if (key == "video" || key == "audio") {
+        isInMediaSection = true;
 
-    if (mediaStateCurr) {
         std::vector<uint8_t> payloadIdList;
         for (size_t i = 2u; i < props.size(); i += 1) {
             if (const auto payloadId = parse_u32(props[i]);
@@ -502,7 +507,13 @@ Error SdpAnswerParser::parseLine_m(const std::string& tag,
             }
         }
 
-        mediaStateCurr->setPayloadList(payloadIdList);
+        mediaState.setPayloadList(payloadIdList);
+
+        if (key == "video") {
+            mediaState.mediaType = MediaType::Video;
+        } else if (key == "audio") {
+            mediaState.mediaType = MediaType::Audio;
+        }
     }
 
     return Error::OK;
@@ -520,10 +531,8 @@ Error SdpAnswerParser::parseLine_a(const std::string& tag,
     } else if (key == "ice-pwd") {
         icePassword = value;
     } else if (key == "setup") {
-        if (mediaStateCurr) {
-            mediaStateCurr->isSetupActive = value == "active";
-        } else if (isApplicationSection) {
-            dataChannelSetupActive = value == "active";
+        if (value == "active") {
+            isSetupActive = true;
         }
     } else if (key == "fingerprint") {
         if (props.size() == 1) {
@@ -536,21 +545,21 @@ Error SdpAnswerParser::parseLine_a(const std::string& tag,
         }
     } else if (key == "extmap") {
         const auto id = parse_u32(value);
-        if (id.has_value() && id >= 0u && id <= 255u) {
-            if (props.size() == 1 && mediaStateCurr) {
-                mediaStateCurr->extensionMap.add(static_cast<uint8_t>(id.value()), props[0]);
+        if (id.has_value() && id > 0 && id <= 255) {
+            if (props.size() == 1 && isInMediaSection) {
+                mediaState.extensionMap.add(static_cast<uint8_t>(id.value()), props[0]);
             }
         }
     } else if (key == "mid") {
         // a=mid:0
-        if (mediaStateCurr && !value.empty()) {
-            mediaStateCurr->mediaId = value;
+        if (isInMediaSection && !value.empty()) {
+            mediaState.mediaId = value;
         }
     } else if (key == "rtpmap") {
         // a=rtpmap:100 H264/90000
         // a=rtpmap:99 opus/48000/2
         if (const auto payloadId = parse_u32(value); payloadId.has_value() && is_valid_payload_id(payloadId.value())) {
-            if (props.size() == 1 && mediaStateCurr) {
+            if (props.size() == 1 && isInMediaSection) {
                 const auto posSlash = props[0].find('/');
                 if (posSlash != std::string::npos) {
                     const auto codecString = props[0].substr(0, posSlash);
@@ -562,7 +571,7 @@ Error SdpAnswerParser::parseLine_a(const std::string& tag,
                         }
                         if (const auto clockRate = parse_u32(clockRateString);
                             clockRate.has_value() && clockRate >= 10000u) {
-                            const auto payloadState = mediaStateCurr->getPayloadState(payloadId.value());
+                            const auto payloadState = mediaState.getPayloadState(payloadId.value());
                             if (payloadState) {
                                 payloadState->codec = codec;
                                 payloadState->clockRate = clockRate.value();
@@ -576,18 +585,17 @@ Error SdpAnswerParser::parseLine_a(const std::string& tag,
     } else if (key == "fmtp") {
         // a=fmtp:100 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f
         if (const auto payloadId = parse_u32(value);
-            payloadId.has_value() && is_valid_payload_id(payloadId.value()) && mediaStateCurr) {
+            payloadId.has_value() && is_valid_payload_id(payloadId.value()) && isInMediaSection) {
             if (props.size() == 1) {
                 std::unordered_map<std::string, std::string> map;
                 parse_map(props[0], map);
 
                 if (const auto iter1 = map.find("apt"); iter1 != map.end()) {
-                    const auto payloadState = mediaStateCurr->getPayloadState(payloadId.value());
+                    const auto payloadState = mediaState.getPayloadState(payloadId.value());
                     if (payloadState && payloadState->codec == Codec::Rtx) {
                         if (const auto referencedPayloadId = parse_u32(iter1->second);
                             referencedPayloadId.has_value() && is_valid_payload_id(referencedPayloadId.value())) {
-                            const auto referencedPayloadState =
-                                mediaStateCurr->getPayloadState(referencedPayloadId.value());
+                            const auto referencedPayloadState = mediaState.getPayloadState(referencedPayloadId.value());
                             if (referencedPayloadState) {
                                 referencedPayloadState->rtxPayloadId = payloadId.value();
                             }
@@ -595,19 +603,19 @@ Error SdpAnswerParser::parseLine_a(const std::string& tag,
                     }
                 }
 
-                const auto payloadState = mediaStateCurr->getPayloadState(payloadId.value());
+                const auto payloadState = mediaState.getPayloadState(payloadId.value());
                 if (payloadState) {
                     uint32_t profileLevelId = 0;
                     uint32_t minptime = 0;
                     bool stereo = false;
 
-                    if (mediaStateCurr == &mediaStateVideo) {
+                    if (mediaState.mediaType.value() == MediaType::Video) {
                         if (const auto iter2 = map.find("profile-level-id"); iter2 != map.end()) {
                             if (const auto parsed = parse_u32(iter2->second, 16); parsed.has_value()) {
                                 profileLevelId = parsed.value();
                             }
                         }
-                    } else if (mediaStateCurr == &mediaStateAudio) {
+                    } else if (mediaState.mediaType.value() == MediaType::Audio) {
                         if (const auto iter2 = map.find("minptime"); iter2 != map.end()) {
                             if (const auto parsed = parse_u32(iter2->second); parsed.has_value()) {
                                 minptime = parsed.value();
@@ -630,8 +638,8 @@ Error SdpAnswerParser::parseLine_a(const std::string& tag,
     } else if (key == "rtcp-fb") {
         // a=rtcp-fb:98 nack pli
         if (const auto payloadId = parse_u32(value);
-            payloadId.has_value() && is_valid_payload_id(payloadId.value()) && mediaStateCurr) {
-            const auto payloadState = mediaStateCurr->getPayloadState(payloadId.value());
+            payloadId.has_value() && is_valid_payload_id(payloadId.value()) && isInMediaSection) {
+            const auto payloadState = mediaState.getPayloadState(payloadId.value());
             if (payloadState) {
                 for (size_t i = 0u; i < props.size(); i += 1) {
                     const auto& token = props[i];
@@ -645,20 +653,20 @@ Error SdpAnswerParser::parseLine_a(const std::string& tag,
         }
     } else if (key == "rid") {
         // a=rid:low
-        if (mediaStateCurr && mediaStateCurr == &mediaStateVideo) {
+        if (isInMediaSection && mediaState.mediaType.value() == MediaType::Video) {
             if (props.size() == 1 && props[0] == "recv") {
-                mediaStateCurr->ridList.push_back(value);
+                mediaState.ridList.push_back(value);
             }
         }
     } else if (key == "simulcast") {
         // a=simulcast recv low;mid;hi
-        if (mediaStateCurr && mediaStateCurr == &mediaStateVideo) {
+        if (isInMediaSection && mediaState.mediaType.value() == MediaType::Video) {
             if (value == "recv" && props.size() == 1) {
                 const auto offerLayerList = offer->getVideoSimulcastLayerList();
                 if (offerLayerList.has_value()) {
                     const auto ridList = split_list(props[0]);
                     for (const auto& ridName : ridList) {
-                        mediaStateCurr->addSimulcastLayer(offerLayerList.value(), ridName);
+                        mediaState.addSimulcastLayer(offerLayerList.value(), ridName);
                     }
                 }
             }
@@ -705,33 +713,84 @@ Error SdpAnswerParser::parseLine_a(const std::string& tag,
         if (value == "FID" && props.size() == 2) {
             const auto ssrcMedia = parse_u32(props[0]);
             const auto ssrcRtx = parse_u32(props[1]);
-            if (mediaStateCurr && ssrcMedia.has_value() && ssrcRtx.has_value()) {
-                mediaStateCurr->ssrc = ssrcMedia.value();
-                mediaStateCurr->rtxSsrc = ssrcRtx.value();
+            if (isInMediaSection && ssrcMedia.has_value() && ssrcRtx.has_value()) {
+                mediaState.ssrc = ssrcMedia.value();
+                mediaState.rtxSsrc = ssrcRtx.value();
             }
         }
     } else if (key == "ssrc") {
         const auto ssrcMedia = parse_u32(value);
-        if (mediaStateCurr && ssrcMedia.has_value()) {
-            if (std::find_if(
-                    mediaStateCurr->ssrcList.begin(), mediaStateCurr->ssrcList.end(), [ssrcMedia](uint32_t ssrc) {
-                        return ssrc == ssrcMedia;
-                    }) == mediaStateCurr->ssrcList.end()) {
-                mediaStateCurr->ssrcList.push_back(ssrcMedia.value());
+        if (isInMediaSection && ssrcMedia.has_value()) {
+            if (std::find_if(mediaState.ssrcList.begin(), mediaState.ssrcList.end(), [ssrcMedia](uint32_t ssrc) {
+                    return ssrc == ssrcMedia;
+                }) == mediaState.ssrcList.end()) {
+                mediaState.ssrcList.push_back(ssrcMedia.value());
             }
         }
     } else if (key == "sctp-port") {
-        if (isApplicationSection) {
+        if (isInApplicationSection) {
             if (const auto port = parse_u32(value); port.has_value() && port > 0u && port <= 65535u) {
                 sctpPort = static_cast<uint16_t>(port.value());
             }
         }
     } else if (key == "max-message-size") {
-        if (isApplicationSection) {
+        if (isInApplicationSection) {
             if (const auto size = parse_u32(value); size.has_value()) {
                 maxSctpMessageSize = size.value();
             }
         }
+    }
+
+    return Error::OK;
+}
+
+Error SdpAnswerParser::flush_m()
+{
+    if (isInMediaSection) {
+        if (!mediaState.mediaType.has_value()) {
+            return { Error::Code::InvalidData, "An unsupported media type" };
+        }
+        if (mediaState.mediaId.empty()) {
+            return { Error::Code::InvalidData, "Media id cannot be empty" };
+        }
+
+        const auto type = mediaState.mediaType.value();
+
+        if (direction == Direction::Publish) {
+            if (type == MediaType::Video) {
+                mediaState.ssrc = offer->getVideoSSRC();
+                mediaState.rtxSsrc = offer->getRtxVideoSSRC();
+            } else if (type == MediaType::Audio) {
+                mediaState.ssrc = offer->getAudioSSRC();
+                mediaState.rtxSsrc = offer->getRtxAudioSSRC();
+            }
+        }
+
+        // Create media and track
+        const auto media = mediaState.createMedia();
+
+        auto track = mediaState.selectTrack(direction, media, selector);
+        if (track == nullptr) {
+            return { Error::Code::InvalidData, "Cannot create a media track" };
+        }
+
+        // If simulcast, create layer tracks
+        std::vector<std::shared_ptr<Track>> simulcastTrackList;
+        if (!mediaState.layerList.empty()) {
+            simulcastTrackList = mediaState.makeSimulcastTrackList(offer, track);
+            track.reset();
+        }
+
+        mediaList.push_back(media);
+
+        if (track) {
+            trackList.push_back(track);
+        } else if (!simulcastTrackList.empty()) {
+            trackList.insert(trackList.end(), simulcastTrackList.begin(), simulcastTrackList.end());
+        }
+
+        // We know that we have media
+        hasMedia = true;
     }
 
     return Error::OK;
@@ -742,17 +801,16 @@ std::pair<std::shared_ptr<SdpAnswer>, Error> SdpAnswer::parse(Direction directio
                                                               const std::string& answer,
                                                               const std::shared_ptr<TrackSelector>& selector)
 {
-    SdpAnswerParser parser(direction, offer);
-    return parser.parse(answer, selector);
+    SdpAnswerParser parser(offer, selector);
+    return parser.parse(answer);
 }
 
 SdpAnswer::SdpAnswer(Direction direction,
                      const std::string& iceUFrag,
                      const std::string& icePassword,
                      const std::vector<Host>& hostList,
-                     const std::shared_ptr<Track>& videoSingleTrack,
-                     const std::vector<std::shared_ptr<Track>>& videoSimulcastTrackList,
-                     const std::shared_ptr<Track>& audioTrack,
+                     const std::vector<std::shared_ptr<Media>>& mediaList,
+                     const std::vector<std::shared_ptr<Track>>& trackList,
                      bool isSetupActive,
                      const X509Hash& certHash,
                      bool hasDataChannel,
@@ -762,9 +820,8 @@ SdpAnswer::SdpAnswer(Direction direction,
     , mIceUFrag(iceUFrag)
     , mIcePassword(icePassword)
     , mHostList(hostList)
-    , mVideoSingleTrack(videoSingleTrack)
-    , mVideoSimulcastTrackList(videoSimulcastTrackList)
-    , mAudioTrack(audioTrack)
+    , mMediaList(mediaList)
+    , mTrackList(trackList)
     , mIsSetupActive(isSetupActive)
     , mCertHash(certHash)
     , mHasDataChannel(hasDataChannel)
@@ -795,34 +852,60 @@ std::vector<Host> SdpAnswer::getHostList() const
     return mHostList;
 }
 
-bool SdpAnswer::hasVideoMedia() const
-{
-    return mVideoSingleTrack != nullptr || !mVideoSimulcastTrackList.empty();
-}
-
 bool SdpAnswer::isVideoSimulcast() const
 {
-    return mVideoSingleTrack == nullptr && !mVideoSimulcastTrackList.empty();
+    return std::find_if(mTrackList.begin(), mTrackList.end(), [](const std::shared_ptr<Track>& track) {
+               return track->getMedia()->getType() == MediaType::Video && track->isSimulcast();
+           }) != mTrackList.end();
 }
 
 std::shared_ptr<Track> SdpAnswer::getVideoSingleTrack() const
 {
-    return mVideoSingleTrack;
+    for (const auto& track : mTrackList) {
+        if (track->getMedia()->getType() == MediaType::Video) {
+            if (!track->isSimulcast()) {
+                return track;
+            }
+        }
+    }
+
+    return {};
 }
 
 std::vector<std::shared_ptr<Track>> SdpAnswer::getVideoSimulcastTrackList() const
 {
-    return mVideoSimulcastTrackList;
-}
+    std::vector<std::shared_ptr<Track>> list;
 
-bool SdpAnswer::hasAudioMedia() const
-{
-    return mAudioTrack != nullptr;
+    for (const auto& track : mTrackList) {
+        if (track->getMedia()->getType() == MediaType::Video) {
+            if (track->isSimulcast()) {
+                list.push_back(track);
+            }
+        }
+    }
+
+    return list;
 }
 
 std::shared_ptr<Track> SdpAnswer::getAudioTrack() const
 {
-    return mAudioTrack;
+    for (const auto& track : mTrackList) {
+        if (track->getMedia()->getType() == MediaType::Audio) {
+            return track;
+        }
+    }
+
+    return {};
+}
+
+std::vector<std::shared_ptr<Media>> SdpAnswer::getMediaList() const
+{
+    return mMediaList;
+}
+
+std::vector<std::shared_ptr<Track>> SdpAnswer::getTrackList() const
+{
+    return mTrackList;
 }
 
 bool SdpAnswer::isSetupActive() const

--- a/src/sdp_answer.cpp
+++ b/src/sdp_answer.cpp
@@ -256,7 +256,7 @@ std::shared_ptr<srtc::Track> ParseMediaState::selectTrack(srtc::Direction direct
         }
     }
 
-    const auto media = std::make_shared<srtc::Media>(mediaId, mediaType.value());
+    const auto media = std::make_shared<srtc::Media>(mediaId, mediaType.value(), extensionMap);
 
     std::vector<std::shared_ptr<srtc::Track>> list;
     for (size_t i = 0u; i < payloadStateSize; i += 1) {
@@ -431,8 +431,6 @@ std::pair<std::shared_ptr<SdpAnswer>, Error> SdpAnswerParser::parse(const std::s
                       videoSingleTrack,
                       videoSimulcastTrackList,
                       audioTrack,
-                      mediaStateVideo.extensionMap,
-                      mediaStateAudio.extensionMap,
                       mediaStateVideo.isSetupActive || mediaStateAudio.isSetupActive || dataChannelSetupActive,
                       { certHashAlg, certHashBin, certHashHex },
                       hasDataChannel,
@@ -755,8 +753,6 @@ SdpAnswer::SdpAnswer(Direction direction,
                      const std::shared_ptr<Track>& videoSingleTrack,
                      const std::vector<std::shared_ptr<Track>>& videoSimulcastTrackList,
                      const std::shared_ptr<Track>& audioTrack,
-                     const ExtensionMap& videoExtensionMap,
-                     const ExtensionMap& audioExtensionMap,
                      bool isSetupActive,
                      const X509Hash& certHash,
                      bool hasDataChannel,
@@ -769,8 +765,6 @@ SdpAnswer::SdpAnswer(Direction direction,
     , mVideoSingleTrack(videoSingleTrack)
     , mVideoSimulcastTrackList(videoSimulcastTrackList)
     , mAudioTrack(audioTrack)
-    , mVideoExtensionMap(videoExtensionMap)
-    , mAudioExtensionMap(audioExtensionMap)
     , mIsSetupActive(isSetupActive)
     , mCertHash(certHash)
     , mHasDataChannel(hasDataChannel)
@@ -794,16 +788,6 @@ std::string SdpAnswer::getIceUFrag() const
 std::string SdpAnswer::getIcePassword() const
 {
     return mIcePassword;
-}
-
-const ExtensionMap& SdpAnswer::getVideoExtensionMap() const
-{
-    return mVideoExtensionMap;
-}
-
-const ExtensionMap& SdpAnswer::getAudioExtensionMap() const
-{
-    return mAudioExtensionMap;
 }
 
 std::vector<Host> SdpAnswer::getHostList() const

--- a/src/sdp_answer.cpp
+++ b/src/sdp_answer.cpp
@@ -285,7 +285,7 @@ std::shared_ptr<srtc::Track> ParseMediaState::selectTrack(srtc::Direction direct
         return nullptr;
     }
 
-    const auto selected = selector == nullptr ? list[0] : selector->selectTrack(mediaType.value(), list);
+    const auto selected = selector == nullptr ? list[0] : selector->selectTrack(list);
     assert(selected != nullptr);
     return selected;
 }

--- a/src/sdp_offer.cpp
+++ b/src/sdp_offer.cpp
@@ -53,22 +53,12 @@ constexpr uint32_t kSctpMaxMessageSize = 262144;
 namespace srtc
 {
 
-SdpOffer::SdpOffer(Direction direction,
-                   const Config& config,
-                   const std::optional<VideoConfig>& videoConfig,
-                   const std::optional<AudioConfig>& audioConfig)
+SdpOffer::SdpOffer(Direction direction, const Config& config, const std::vector<MediaLine>& media)
     : mRandomGenerator(0, 0x7ffffffe)
     , mDirection(direction)
     , mConfig(config)
-    , mVideoConfig(videoConfig)
-    , mAudioConfig(audioConfig)
+    , mMediaLineList(media)
     , mOriginId((static_cast<uint64_t>(mRandomGenerator.next()) << 32) | mRandomGenerator.next())
-    , mVideoSSRC(1 + mRandomGenerator.next())
-    , mRtxVideoSSRC(1 + mRandomGenerator.next())
-    , mAudioSSRC(1 + mRandomGenerator.next())
-    , mRtxAudioSSRC(1 + mRandomGenerator.next())
-    , mVideoMSID(generateRandomUUID())
-    , mAudioMSID(generateRandomUUID())
     , mIceUfrag(generateRandomString(8))
     , mIcePassword(generateRandomString(24))
     , mCert(std::make_shared<X509Certificate>())
@@ -87,9 +77,10 @@ const SdpOffer::Config& SdpOffer::getConfig() const
 
 std::pair<std::string, Error> SdpOffer::generate()
 {
+    const bool hasMedia = !mMediaLineList.empty();
     const bool hasData = !mConfig.data_channels.empty();
 
-    if (!mVideoConfig.has_value() && !mAudioConfig.has_value() && !hasData) {
+    if (!hasMedia && !hasData) {
         return { "", { Error::Code::InvalidData, "No video, audio, or data channels configured" } };
     }
 
@@ -102,33 +93,63 @@ std::pair<std::string, Error> SdpOffer::generate()
     ss << "a=extmap-allow-mixed" << std::endl;
     ss << "a=msid-semantic: WMS" << std::endl;
 
+    // Bundle
     {
-        const int sectionCount = (mVideoConfig.has_value() ? 1 : 0) +
-                                 (mAudioConfig.has_value() ? 1 : 0) +
-                                 (hasData ? 1 : 0);
+        const auto sectionCount = mMediaLineList.size() + (hasData ? 1 : 0);
         if (sectionCount > 1) {
             ss << "a=group:BUNDLE";
-            for (int i = 0; i < sectionCount; i += 1) {
-                ss << " " << i;
+            for (size_t i = 0; i < sectionCount; i += 1) {
+                if (i < mMediaLineList.size()) {
+                    ss << " " << mMediaLineList[i].id;
+                } else {
+                    ss << " datachannel";
+                }
             }
             ss << std::endl;
         }
     }
 
-    uint32_t mid = 0;
     uint32_t payloadId = 96;
 
-    // Video
-    if (mVideoConfig.has_value()) {
-        const auto& list = mVideoConfig->codec_list;
-        if (list.empty()) {
-            return { "", { Error::Code::InvalidData, "The video config list is present but empty" } };
+    // Media lines
+    for (const auto& mediaLine : mMediaLineList) {
+        const auto& codecList = mediaLine.codec_list;
+        if (codecList.empty()) {
+            return { "", { Error::Code::InvalidData, "A media line is present but has no codecs" } };
         }
 
-        if (mConfig.enable_rtx) {
-            ss << "m=video 9 UDP/TLS/RTP/SAVPF " << list_to_string(payloadId, payloadId + list.size() * 2) << std::endl;
+        for (const auto& codec : codecList) {
+            if (mediaLine.mediaType == MediaType::Audio) {
+                if (!isAudioCodec(codec.codec)) {
+                    return {
+                        "", { Error::Code::InvalidData, "A media line with type audio has a codec that's not audio" }
+                    };
+                }
+            } else if (mediaLine.mediaType == MediaType::Video) {
+                if (!isVideoCodec(codec.codec)) {
+                    return {
+                        "", { Error::Code::InvalidData, "A media line with type video has a codec that's not video" }
+                    };
+                }
+            }
+        }
+
+        mMediaLineGeneratedList.emplace_back(mediaLine.id);
+        auto& mediaLineGenerated = mMediaLineGeneratedList.back();
+        mediaLineGenerated.mediaType = mediaLine.mediaType;
+
+        ss << "m=";
+        if (mediaLine.mediaType == MediaType::Video) {
+            ss << "video";
         } else {
-            ss << "m=video 9 UDP/TLS/RTP/SAVPF " << list_to_string(payloadId, payloadId + list.size()) << std::endl;
+            ss << "audio";
+        }
+        ss << " 9 UDP/TLS/RTP/SAVPF ";
+
+        if (mConfig.enable_rtx) {
+            ss << list_to_string(payloadId, payloadId + codecList.size() * 2) << std::endl;
+        } else {
+            ss << list_to_string(payloadId, payloadId + codecList.size()) << std::endl;
         }
 
         ss << "c=IN IP4 0.0.0.0" << std::endl;
@@ -137,8 +158,7 @@ std::pair<std::string, Error> SdpOffer::generate()
         ss << "a=ice-ufrag:" << mIceUfrag << std::endl;
         ss << "a=ice-pwd:" << mIcePassword << std::endl;
         ss << "a=setup:actpass" << std::endl;
-        ss << "a=mid:" << mid << std::endl;
-        mid += 1;
+        ss << "a=mid:" << mediaLine.id << std::endl;
 
         if (mDirection == Direction::Publish) {
             ss << "a=sendonly" << std::endl;
@@ -151,17 +171,24 @@ std::pair<std::string, Error> SdpOffer::generate()
         ss << "a=rtcp-mux" << std::endl;
         ss << "a=rtcp-rsize" << std::endl;
 
-        for (const auto& item : list) {
+        for (const auto& item : codecList) {
             ss << "a=rtpmap:" << payloadId << " " << codec_to_string(item.codec) << std::endl;
             if (item.codec == Codec::H264) {
-                char buf[128];
+                char buf[64];
                 std::snprintf(buf, sizeof(buf), "%06x", item.profile_level_id);
 
                 ss << "a=fmtp:" << payloadId
                    << " level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=" << buf << std::endl;
+            } else if (item.codec == Codec::Opus) {
+                ss << "a=fmtp:" << payloadId << " minptime=" << item.minptime << ";stereo=" << (item.stereo ? 1 : 0)
+                   << ";useinbandfec=1" << std::endl;
             }
+
             ss << "a=rtcp-fb:" << payloadId << " nack" << std::endl;
-            ss << "a=rtcp-fb:" << payloadId << " nack pli" << std::endl;
+
+            if (mediaLineGenerated.mediaType == MediaType::Video) {
+                ss << "a=rtcp-fb:" << payloadId << " nack pli" << std::endl;
+            }
 
             if (mConfig.enable_rtx) {
                 const auto payloadIdRtx = payloadId + 1;
@@ -174,22 +201,28 @@ std::pair<std::string, Error> SdpOffer::generate()
             }
         }
 
-        const auto& layerList = mVideoConfig->simulcast_layer_list;
+        const auto msid = generateRandomUUID();
+
+        const auto& layerList = mediaLine.layer_list;
         if (layerList.empty() || mDirection == Direction::Subscribe) {
             // No simulcast or subscribe
             if (mConfig.enable_bwe || mDirection == Direction::Subscribe) {
                 ss << "a=extmap:14 " << RtpStandardExtensions::kExtGoogleTWCC << std::endl;
             }
 
-            ss << "a=ssrc:" << mVideoSSRC << " cname:" << mConfig.cname << std::endl;
-            ss << "a=ssrc:" << mVideoSSRC << " msid:" << mConfig.cname << " " << mVideoMSID << std::endl;
+            mediaLineGenerated.ssrc = 1 + mRandomGenerator.next();
+
+            ss << "a=ssrc:" << mediaLineGenerated.ssrc << " cname:" << mConfig.cname << std::endl;
+            ss << "a=ssrc:" << mediaLineGenerated.ssrc << " msid:" << mConfig.cname << " " << msid << std::endl;
 
             if (mConfig.enable_rtx) {
-                ss << "a=ssrc:" << mRtxVideoSSRC << " cname:" << mConfig.cname << std::endl;
-                ss << "a=ssrc:" << mRtxVideoSSRC << " msid:" << mConfig.cname << " " << mVideoMSID << std::endl;
+                mediaLineGenerated.rtx = 1 + mRandomGenerator.next();
+
+                ss << "a=ssrc:" << mediaLineGenerated.rtx << " cname:" << mConfig.cname << std::endl;
+                ss << "a=ssrc:" << mediaLineGenerated.rtx << " msid:" << mConfig.cname << " " << msid << std::endl;
 
                 // https://groups.google.com/g/discuss-webrtc/c/0OVDV6I3SRo
-                ss << "a=ssrc-group:FID " << mVideoSSRC << " " << mRtxVideoSSRC << std::endl;
+                ss << "a=ssrc-group:FID " << mediaLineGenerated.ssrc << " " << mediaLineGenerated.rtx << std::endl;
             }
         } else {
             // Simulcast
@@ -227,88 +260,22 @@ std::pair<std::string, Error> SdpOffer::generate()
             ss << std::endl;
 
             for (const auto& layer : layerList) {
-                const auto videoSSRC = 1 + mRandomGenerator.next();
-                const auto videoRtxSSRC = 1 + mRandomGenerator.next();
+                mediaLineGenerated.layer.emplace_back(layer.name);
+                auto& layerGenerated = mediaLineGenerated.layer.back();
+                layerGenerated.ssrc = 1 + mRandomGenerator.next();
 
-                mLayerSSRC.push_back({ layer.name, videoSSRC, videoRtxSSRC });
-
-                ss << "a=ssrc:" << videoSSRC << " cname:" << mConfig.cname << std::endl;
-                ss << "a=ssrc:" << videoSSRC << " msid:" << mConfig.cname << " " << mVideoMSID << std::endl;
+                ss << "a=ssrc:" << layerGenerated.ssrc << " cname:" << mConfig.cname << std::endl;
+                ss << "a=ssrc:" << layerGenerated.ssrc << " msid:" << mConfig.cname << " " << msid << std::endl;
 
                 if (mConfig.enable_rtx) {
-                    ss << "a=ssrc:" << videoRtxSSRC << " cname:" << mConfig.cname << std::endl;
-                    ss << "a=ssrc:" << videoRtxSSRC << " msid:" << mConfig.cname << " " << mVideoMSID << std::endl;
+                    layerGenerated.rtx = 1 + mRandomGenerator.next();
 
-                    ss << "a=ssrc-group:FID " << videoSSRC << " " << videoRtxSSRC << std::endl;
+                    ss << "a=ssrc:" << layerGenerated.rtx << " cname:" << mConfig.cname << std::endl;
+                    ss << "a=ssrc:" << layerGenerated.rtx << " msid:" << mConfig.cname << " " << msid << std::endl;
+
+                    ss << "a=ssrc-group:FID " << layerGenerated.ssrc << " " << layerGenerated.rtx << std::endl;
                 }
             }
-        }
-    }
-
-    // Audio
-    if (mAudioConfig.has_value()) {
-        const auto& list = mAudioConfig->codec_list;
-        if (list.empty()) {
-            return { "", { Error::Code::InvalidData, "The audio config list is present but empty" } };
-        }
-
-        if (mConfig.enable_rtx) {
-            ss << "m=audio 9 UDP/TLS/RTP/SAVPF " << list_to_string(payloadId, payloadId + list.size() * 2) << std::endl;
-        } else {
-            ss << "m=audio 9 UDP/TLS/RTP/SAVPF " << list_to_string(payloadId, payloadId + list.size()) << std::endl;
-        }
-
-        ss << "c=IN IP4 0.0.0.0" << std::endl;
-        ss << "a=rtcp:9 IN IP4 0.0.0.0" << std::endl;
-        ss << "a=fingerprint:sha-256 " << mCert->getSha256FingerprintHex() << std::endl;
-        ss << "a=ice-ufrag:" << mIceUfrag << std::endl;
-        ss << "a=ice-pwd:" << mIcePassword << std::endl;
-        ss << "a=setup:actpass" << std::endl;
-        ss << "a=mid:" << mid << std::endl;
-        mid += 1;
-
-        if (mDirection == Direction::Publish) {
-            ss << "a=sendonly" << std::endl;
-        } else if (mDirection == Direction::Subscribe) {
-            ss << "a=recvonly" << std::endl;
-        } else {
-            assert(false);
-        }
-
-        ss << "a=rtcp-mux" << std::endl;
-        ss << "a=rtcp-rsize" << std::endl;
-
-        for (const auto& item : list) {
-            ss << "a=rtpmap:" << payloadId << " " << codec_to_string(item.codec) << std::endl;
-            if (item.codec == Codec::Opus) {
-                ss << "a=fmtp:" << payloadId << " minptime=" << item.minptime << ";stereo=" << (item.stereo ? 1 : 0)
-                   << ";useinbandfec=1" << std::endl;
-            }
-
-            if (mConfig.enable_rtx) {
-                const auto payloadIdRtx = payloadId + 1;
-                ss << "a=rtpmap:" << payloadIdRtx << " rtx/48000" << std::endl;
-                ss << "a=fmtp:" << payloadIdRtx << " apt=" << payloadId << std::endl;
-
-                payloadId += 2;
-            } else {
-                payloadId += 1;
-            }
-        }
-
-        if (mConfig.enable_bwe || mDirection == Direction::Subscribe) {
-            ss << "a=extmap:14 " << RtpStandardExtensions::kExtGoogleTWCC << std::endl;
-        }
-
-        ss << "a=ssrc:" << mAudioSSRC << " cname:" << mConfig.cname << std::endl;
-        ss << "a=ssrc:" << mAudioSSRC << " msid:" << mConfig.cname << " " << mAudioMSID << std::endl;
-
-        if (mConfig.enable_rtx) {
-            ss << "a=ssrc:" << mRtxAudioSSRC << " cname:" << mConfig.cname << std::endl;
-            ss << "a=ssrc:" << mRtxAudioSSRC << " msid:" << mConfig.cname << " " << mAudioMSID << std::endl;
-
-            // https://groups.google.com/g/discuss-webrtc/c/0OVDV6I3SRo
-            ss << "a=ssrc-group:FID " << mAudioSSRC << " " << mRtxAudioSSRC << std::endl;
         }
     }
 
@@ -320,21 +287,12 @@ std::pair<std::string, Error> SdpOffer::generate()
         ss << "a=ice-ufrag:" << mIceUfrag << std::endl;
         ss << "a=ice-pwd:" << mIcePassword << std::endl;
         ss << "a=setup:actpass" << std::endl;
-        ss << "a=mid:" << mid << std::endl;
+        ss << "a=mid:datachannel" << std::endl;
         ss << "a=sctp-port:" << kSctpPort << std::endl;
         ss << "a=max-message-size:" << kSctpMaxMessageSize << std::endl;
     }
 
     return { ss.str(), Error::OK };
-}
-
-std::optional<std::vector<SimulcastLayer>> SdpOffer::getVideoSimulcastLayerList() const
-{
-    if (mVideoConfig.has_value()) {
-        return mVideoConfig->simulcast_layer_list;
-    }
-
-    return std::nullopt;
 }
 
 std::string SdpOffer::getIceUFrag() const
@@ -352,31 +310,40 @@ std::shared_ptr<X509Certificate> SdpOffer::getCertificate() const
     return mCert;
 }
 
-uint32_t SdpOffer::getVideoSSRC() const
+std::optional<std::vector<SimulcastLayer>> SdpOffer::getVideoSimulcastLayerList(const std::string& mediaId) const
 {
-    return mVideoSSRC;
+    for (const auto& mediaLine : mMediaLineList) {
+        if (mediaLine.id == mediaId) {
+            if (mediaLine.layer_list.empty()) {
+                return std::nullopt;
+            }
+            return mediaLine.layer_list;
+        }
+    }
+
+    return std::nullopt;
 }
 
-uint32_t SdpOffer::getRtxVideoSSRC() const
+std::pair<uint32_t, uint32_t> SdpOffer::getMediaSSRC(const std::string& mediaId) const
 {
-    return mRtxVideoSSRC;
+    for (const auto& mediaItem : mMediaLineGeneratedList) {
+        if (mediaItem.mediaId == mediaId) {
+            return { mediaItem.ssrc, mediaItem.rtx };
+        }
+    }
+
+    return {};
 }
 
-uint32_t SdpOffer::getAudioSSRC() const
+std::pair<uint32_t, uint32_t> SdpOffer::getVideoSimulastSSRC(const std::string& mediaId, const std::string& name) const
 {
-    return mAudioSSRC;
-}
-
-uint32_t SdpOffer::getRtxAudioSSRC() const
-{
-    return mRtxAudioSSRC;
-}
-
-std::pair<uint32_t, uint32_t> SdpOffer::getVideoSimulastSSRC(const std::string& name) const
-{
-    for (const auto& item : mLayerSSRC) {
-        if (item.name == name) {
-            return std::make_pair(item.ssrc, item.rtx);
+    for (const auto& mediaItem : mMediaLineGeneratedList) {
+        if (mediaItem.mediaId == mediaId) {
+            for (const auto& layerItem : mediaItem.layer) {
+                if (layerItem.name == name) {
+                    return std::make_pair(layerItem.ssrc, layerItem.rtx);
+                }
+            }
         }
     }
 

--- a/src/send_pacer.cpp
+++ b/src/send_pacer.cpp
@@ -176,7 +176,7 @@ void SendPacer::sendImpl(const std::shared_ptr<RtpPacket>& packet)
 #else
         // In debug mode, we have deliberate 5% packet loss to validate that NACK / RTX processing works
         const auto randomValue = mLosePacketsRandomGenerator.next();
-        if (mOfferConfig.debug_drop_packets && randomValue < 5 && track->getMedia()->getType() == MediaType::Video) {
+        if (mOfferConfig.debug_drop_packets && randomValue < 5 && track->getMediaType() == MediaType::Video) {
             const auto twcc = mTWCC ? mTWCC->getFeedbackSeq(packet) : std::nullopt;
             if (twcc.has_value()) {
                 LOG(SRTC_LOG_V, "NOT sending packet %u, twcc %u", packet->getSequence(), twcc.value());

--- a/src/send_pacer.cpp
+++ b/src/send_pacer.cpp
@@ -169,27 +169,6 @@ void SendPacer::sendImpl(const std::shared_ptr<RtpPacket>& packet)
         if (mOnSend) {
             mOnSend();
         }
-
-#ifdef NDEBUG
-        // Send
-        (void)mSocket->send(protectedData.data(), protectedData.size());
-#else
-        // In debug mode, we have deliberate 5% packet loss to validate that NACK / RTX processing works
-        const auto randomValue = mLosePacketsRandomGenerator.next();
-        if (mOfferConfig.debug_drop_packets && randomValue < 5 && track->getMediaType() == MediaType::Video) {
-            const auto twcc = mTWCC ? mTWCC->getFeedbackSeq(packet) : std::nullopt;
-            if (twcc.has_value()) {
-                LOG(SRTC_LOG_V, "NOT sending packet %u, twcc %u", packet->getSequence(), twcc.value());
-            } else {
-                LOG(SRTC_LOG_V, "NOT sending packet %u", packet->getSequence());
-            }
-        } else {
-            const auto w = mSocket->send(protectedData.data(), protectedData.size());
-            // This is too much
-            // LOG(SRTC_LOG_V, "Sent %zu bytes of RTP media", w);
-            (void)w;
-        }
-#endif
     }
 }
 

--- a/src/send_pacer.cpp
+++ b/src/send_pacer.cpp
@@ -1,5 +1,6 @@
 #include "srtc/send_pacer.h"
 #include "srtc/logging.h"
+#include "srtc/media.h"
 #include "srtc/rtp_extension_source_twcc.h"
 #include "srtc/rtp_packet.h"
 #include "srtc/send_rtp_history.h"
@@ -175,7 +176,7 @@ void SendPacer::sendImpl(const std::shared_ptr<RtpPacket>& packet)
 #else
         // In debug mode, we have deliberate 5% packet loss to validate that NACK / RTX processing works
         const auto randomValue = mLosePacketsRandomGenerator.next();
-        if (mOfferConfig.debug_drop_packets && randomValue < 5 && track->getMediaType() == MediaType::Video) {
+        if (mOfferConfig.debug_drop_packets && randomValue < 5 && track->getMedia()->getType() == MediaType::Video) {
             const auto twcc = mTWCC ? mTWCC->getFeedbackSeq(packet) : std::nullopt;
             if (twcc.has_value()) {
                 LOG(SRTC_LOG_V, "NOT sending packet %u, twcc %u", packet->getSequence(), twcc.value());

--- a/src/srtc.cpp
+++ b/src/srtc.cpp
@@ -12,6 +12,39 @@
 namespace srtc
 {
 
+bool isVideoCodec(Codec codec)
+{
+    switch (codec) {
+    case Codec::VP8:
+    case Codec::VP9:
+    case Codec::H264:
+    case Codec::H265:
+    case Codec::AV1:
+        return true;
+    case Codec::Opus:
+    case Codec::Rtx:
+        break;
+    }
+    return false;
+}
+
+bool isAudioCodec(Codec codec)
+{
+    switch (codec) {
+    case Codec::VP8:
+    case Codec::VP9:
+    case Codec::H264:
+    case Codec::H265:
+    case Codec::AV1:
+    case Codec::Rtx:
+        break;
+    case Codec::Opus:
+        return true;
+    }
+
+    return false;
+}
+
 std::string to_string(MediaType m)
 {
     switch (m) {

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -1,4 +1,6 @@
 #include "srtc/track.h"
+
+#include "srtc/media.h"
 #include "srtc/rtcp_packet_source.h"
 #include "srtc/rtp_packet_source.h"
 #include "srtc/rtp_time_source.h"
@@ -44,6 +46,11 @@ Track::Track(const std::shared_ptr<Media>& media,
 std::shared_ptr<Media> Track::getMedia() const
 {
     return mMedia;
+}
+
+MediaType Track::getMediaType() const
+{
+    return mMedia->getType();
 }
 
 Direction Track::getDirection() const

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -9,10 +9,8 @@ namespace srtc
 
 // Track
 
-Track::Track(uint32_t trackId,
+Track::Track(const std::shared_ptr<Media>& media,
              Direction direction,
-             MediaType mediaType,
-             const std::string& mediaId,
              uint32_t ssrtc,
              uint8_t payloadId,
              uint32_t rtxSsrc,
@@ -23,10 +21,8 @@ Track::Track(uint32_t trackId,
              uint32_t clockRate,
              bool hasNack,
              bool hasPli)
-    : mTrackId(trackId)
+    : mMedia(media)
     , mDirection(direction)
-    , mMediaType(mediaType)
-    , mMediaId(mediaId)
     , mSSRC(ssrtc)
     , mPayloadId(payloadId)
     , mRtxSSRC(rtxSsrc)
@@ -45,24 +41,14 @@ Track::Track(uint32_t trackId,
 {
 }
 
-uint32_t Track::getTrackId() const
+std::shared_ptr<Media> Track::getMedia() const
 {
-    return mTrackId;
+    return mMedia;
 }
 
 Direction Track::getDirection() const
 {
     return mDirection;
-}
-
-MediaType Track::getMediaType() const
-{
-    return mMediaType;
-}
-
-std::string Track::getMediaId() const
-{
-    return mMediaId;
 }
 
 uint8_t Track::getPayloadId() const
@@ -147,17 +133,10 @@ std::shared_ptr<TrackStats> Track::getStats() const
 
 // TrackBuilder
 
-TrackBuilder::TrackBuilder(uint32_t trackId,
-                           Direction direction,
-                           MediaType mediaType,
-                           const std::string& mediaId,
-                           uint32_t ssrc,
-                           uint8_t payloadId,
-                           uint32_t clockRate)
-    : mTrackId(trackId)
+TrackBuilder::TrackBuilder(
+    const std::shared_ptr<Media>& media, Direction direction, uint32_t ssrc, uint8_t payloadId, uint32_t clockRate)
+    : mMedia(media)
     , mDirection(direction)
-    , mMediaType(mediaType)
-    , mMediaId(mediaId)
     , mSSRC(ssrc)
     , mPayloadId(payloadId)
     , mClockRate(clockRate)
@@ -204,10 +183,8 @@ TrackBuilder& TrackBuilder::pli(bool pli)
 
 std::shared_ptr<Track> TrackBuilder::build() const
 {
-    return std::make_shared<Track>(mTrackId,
+    return std::make_shared<Track>(mMedia,
                                    mDirection,
-                                   mMediaType,
-                                   mMediaId,
                                    mSSRC,
                                    mPayloadId,
                                    mRtxSSRC,

--- a/src/track_selector.cpp
+++ b/src/track_selector.cpp
@@ -1,4 +1,5 @@
 #include "srtc/track_selector.h"
+#include "srtc/media.h"
 #include "srtc/track.h"
 
 namespace
@@ -28,26 +29,30 @@ bool isBetter(const std::shared_ptr<srtc::Track>& best, const std::shared_ptr<sr
 namespace srtc
 {
 
-std::shared_ptr<srtc::Track> HighestTrackSelector::selectTrack(
-    srtc::MediaType type, const std::vector<std::shared_ptr<srtc::Track>>& list) const
+std::shared_ptr<Track> HighestTrackSelector::selectTrack(const std::vector<std::shared_ptr<Track>>& list) const
 {
     if (list.empty()) {
         return nullptr;
     }
 
-    if (type == srtc::MediaType::Audio) {
+    // All tracks must have the same media
+    const auto type = list[0]->getMedia()->getType();
+
+    if (type == MediaType::Audio) {
         return list[0];
-    } else if (type == srtc::MediaType::Video) {
-        std::shared_ptr<srtc::Track> best;
+    }
+
+    if (type == MediaType::Video) {
+        std::shared_ptr<Track> best;
         for (const auto& curr : list) {
             if (isBetter(best, curr)) {
                 best = curr;
             }
         }
         return best;
-    } else {
-        return nullptr;
     }
+
+    return {};
 }
 
 } // namespace srtc

--- a/src/track_selector.cpp
+++ b/src/track_selector.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<Track> HighestTrackSelector::selectTrack(const std::vector<std::
     }
 
     // All tracks must have the same media
-    const auto type = list[0]->getMedia()->getType();
+    const auto type = list[0]->getMediaType();
 
     if (type == MediaType::Audio) {
         return list[0];

--- a/src/twcc_publish.cpp
+++ b/src/twcc_publish.cpp
@@ -134,7 +134,7 @@ void PublishPacketHistory::saveOutgoingPacket(uint16_t seq,
     curr->generated_size = static_cast<uint16_t>(generatedSize);
     curr->encrypted_size = static_cast<uint16_t>(encryptedSize);
     curr->sent_time_micros = getStableTimeMicros();
-    curr->media_type = track->getMedia()->getType();
+    curr->media_type = track->getMediaType();
 }
 
 PublishPacket* PublishPacketHistory::get(uint16_t seq) const

--- a/src/twcc_publish.cpp
+++ b/src/twcc_publish.cpp
@@ -1,5 +1,6 @@
 #include "srtc/twcc_publish.h"
 #include "srtc/logging.h"
+#include "srtc/media.h"
 #include "srtc/track.h"
 #include "srtc/twcc_common.h"
 
@@ -133,7 +134,7 @@ void PublishPacketHistory::saveOutgoingPacket(uint16_t seq,
     curr->generated_size = static_cast<uint16_t>(generatedSize);
     curr->encrypted_size = static_cast<uint16_t>(encryptedSize);
     curr->sent_time_micros = getStableTimeMicros();
-    curr->media_type = track->getMediaType();
+    curr->media_type = track->getMedia()->getType();
 }
 
 PublishPacket* PublishPacketHistory::get(uint16_t seq) const

--- a/test/test_packetizer.cpp
+++ b/test/test_packetizer.cpp
@@ -83,10 +83,10 @@ TEST(Packetizer, h264)
 
     int64_t pts_usec = 1000u;
 
-    const auto extensionSimulcast = std::make_shared<srtc::RtpExtensionSourceSimulcast>(1, 2, 3, 4);
+    const auto extensionSimulcast = std::make_shared<srtc::RtpExtensionSourceSimulcast>();
 
     const auto scheduler = std::make_shared<srtc::ThreadScheduler>("test");
-    const auto extensionTWCC = std::make_shared<srtc::RtpExtensionSourceTWCC>(5, 6, scheduler);
+    const auto extensionTWCC = std::make_shared<srtc::RtpExtensionSourceTWCC>(scheduler);
 
     srtc::ExtendedValue<uint16_t> extendedSeq;
     srtc::ExtendedValue<uint32_t> extendedRtpTime;

--- a/test/test_packetizer.cpp
+++ b/test/test_packetizer.cpp
@@ -4,6 +4,7 @@
 #include "srtc/codec_h264.h"
 #include "srtc/depacketizer_h264.h"
 #include "srtc/extended_value.h"
+#include "srtc/media.h"
 #include "srtc/packetizer_h264.h"
 #include "srtc/rtp_extension_source_simulcast.h"
 #include "srtc/rtp_extension_source_twcc.h"
@@ -64,13 +65,16 @@ TEST(Packetizer, h264)
 
     const auto codecOptions = std::make_shared<srtc::Track::CodecOptions>(0x42e01fu, 0, false);
 
+    const auto mediaPublish = std::make_shared<srtc::Media>("video_0", srtc::MediaType::Video);
     const auto trackPublish =
-        srtc::TrackBuilder(0, srtc::Direction::Publish, srtc::MediaType::Video, "video_0", 1234u, 96u, 90000u)
+        srtc::TrackBuilder(mediaPublish, srtc::Direction::Publish, 1234u, 96u, 90000u)
             .codec(srtc::Codec::H264, codecOptions)
             .simulcastLayer(std::make_shared<srtc::Track::SimulcastLayer>(layer0))
             .build();
+
+    const auto mediaSubscribe = std::make_shared<srtc::Media>("video_0", srtc::MediaType::Video);
     const auto trackSubscribe =
-        srtc::TrackBuilder(0, srtc::Direction::Subscribe, srtc::MediaType::Video, "video_0", 5678u, 96u, 90000u)
+        srtc::TrackBuilder(mediaSubscribe, srtc::Direction::Subscribe, 5678u, 96u, 90000u)
             .codec(srtc::Codec::H264, codecOptions)
             .build();
 

--- a/test/test_rtp_packet.cpp
+++ b/test/test_rtp_packet.cpp
@@ -3,6 +3,7 @@
 #include "srtc/byte_buffer.h"
 #include "srtc/rtp_extension_builder.h"
 #include "srtc/rtp_packet.h"
+#include "srtc/media.h"
 #include "srtc/track.h"
 #include "srtc/util.h"
 
@@ -75,10 +76,9 @@ TEST(RtpPacket, Serialize)
     const auto kSSRC = 0x12345678u;
     const auto kPayloadId = 96u;
 
-    const auto track = std::make_shared<srtc::Track>(1,
+    const auto media = std::make_shared<srtc::Media>("0", srtc::MediaType::Video);
+    const auto track = std::make_shared<srtc::Track>(media,
                                                      srtc::Direction::Subscribe,
-                                                     srtc::MediaType::Video,
-                                                     "0",
                                                      kSSRC,
                                                      kPayloadId,
                                                      0,

--- a/test/test_srtp_crypto.cpp
+++ b/test/test_srtp_crypto.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "srtc/byte_buffer.h"
+#include "srtc/media.h"
 #include "srtc/rtcp_packet.h"
 #include "srtc/rtp_extension.h"
 #include "srtc/rtp_packet.h"
@@ -138,20 +139,9 @@ TEST(SrtpCrypto, SendMedia)
 
         std::optional<uint16_t> prevSequence;
 
-        const auto track = std::make_shared<srtc::Track>(0,
-                                                         srtc::Direction::Publish,
-                                                         srtc::MediaType::Video,
-                                                         "0",
-                                                         ssrc,
-                                                         96,
-                                                         0,
-                                                         0,
-                                                         srtc::Codec::H264,
-                                                         nullptr,
-                                                         nullptr,
-                                                         90000,
-                                                         false,
-                                                         false);
+        const auto media = std::make_shared<srtc::Media>("0", srtc::MediaType::Video);
+        const auto track = std::make_shared<srtc::Track>(
+            media, srtc::Direction::Publish, ssrc, 96, 0, 0, srtc::Codec::H264, nullptr, nullptr, 90000, false, false);
 
         {
             // Edge case 1: empty payload with an extension, not valid in our library
@@ -350,10 +340,9 @@ TEST(SrtpCrypto, ReceiveMedia)
 
         std::optional<uint16_t> prevSequence;
 
-        const auto track = std::make_shared<srtc::Track>(0,
+        const auto media = std::make_shared<srtc::Media>("0", srtc::MediaType::Video);
+        const auto track = std::make_shared<srtc::Track>(media,
                                                          srtc::Direction::Subscribe,
-                                                         srtc::MediaType::Video,
-                                                         "0",
                                                          ssrc,
                                                          96,
                                                          0,

--- a/tools/srtc_publish.cpp
+++ b/tools/srtc_publish.cpp
@@ -50,7 +50,6 @@ static std::string gAuthToken = "none";
 static bool gQuiet = false;
 static bool gPrintSDP = false;
 static bool gPrintInfo = false;
-static bool gDropPackets = false;
 static bool gEnableBWE = false;
 static bool gLoopVideo = false;
 static bool gDataChannels = false;
@@ -173,7 +172,6 @@ void printUsage(const char* programName)
     std::cout << "  -q, --quiet          Suppress progress reporting" << std::endl;
     std::cout << "  -s, --sdp            Print SDP offer and answer" << std::endl;
     std::cout << "  -i, --info           Print input file info" << std::endl;
-    std::cout << "  -d, --drop           Drop some packets at random (test NACK and RTX handling)" << std::endl;
     std::cout << "  -b, --bwe            Enable TWCC congestion control for bandwidth estimation" << std::endl;
     std::cout << "  -c, --datachannels   Enable data channels" << std::endl;
     std::cout << "  -h, --help           Show this help message" << std::endl;
@@ -224,8 +222,6 @@ int main(int argc, char* argv[])
             gPrintSDP = true;
         } else if (arg == "-i" || arg == "--info") {
             gPrintInfo = true;
-        } else if (arg == "-d" || arg == "--drop") {
-            gDropPackets = true;
         } else if (arg == "-b" || arg == "--bwe") {
             gEnableBWE = true;
         } else if (arg == "-c" || arg == "--datachannels") {
@@ -314,7 +310,6 @@ int main(int argc, char* argv[])
     offer_config.cname = "foo";
     offer_config.enable_rtx = true;
     offer_config.enable_bwe = gEnableBWE;
-    offer_config.debug_drop_packets = gDropPackets;
     if (gDataChannels) {
         offer_config.data_channel_config.data_channels.emplace_back("foo");
     }

--- a/tools/srtc_publish.cpp
+++ b/tools/srtc_publish.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <cassert>
 
 #ifdef _WIN32
 #define NOMINMAX
@@ -95,6 +96,11 @@ void playVideoFile(const std::shared_ptr<srtc::PeerConnection>& peerConnection, 
     std::optional<int64_t> pts_usec;
     uint32_t msg_seq = 0;
 
+    const auto trackList = peerConnection->getTrackList();
+    assert(trackList.size() == 1);
+
+    const auto track = trackList[0];
+
     while (true) {
         uint32_t frame_count = 0;
 
@@ -111,10 +117,10 @@ void playVideoFile(const std::shared_ptr<srtc::PeerConnection>& peerConnection, 
                     csd_copy.push_back(item.copy());
                 }
 
-                peerConnection->setVideoSingleCodecSpecificData(std::move(csd_copy));
+                peerConnection->setVideoCodecSpecificData(track, std::move(csd_copy));
             }
 
-            peerConnection->publishVideoSingleFrame(frame.pts_usec, frame.frame.copy());
+            peerConnection->publishVideoFrame(track, frame.pts_usec, frame.frame.copy());
 
             frame_count += 1;
 
@@ -313,16 +319,21 @@ int main(int argc, char* argv[])
         offer_config.data_channel_config.data_channels.emplace_back("foo");
     }
 
-    PubVideoCodec video_codec = {};
+    PubCodec video_codec = {};
     video_codec.codec = media_file.codec;
     if (video_codec.codec == Codec::H264) {
         video_codec.profile_level_id = 0x42e01f;
     }
 
-    PubVideoConfig video_config = {};
-    video_config.codec_list.push_back(video_codec);
+    PubMediaItem media_item = {};
+    media_item.media_type = MediaType::Video;
+    media_item.media_id = "video_0";
+    media_item.codec_list.push_back(video_codec);
 
-    const auto [offer, offerCreateError] = peerConnection->createPublishOffer(offer_config, video_config, std::nullopt);
+    PubMediaConfig media_config = {};
+    media_config.media_list.push_back(media_item);
+
+    const auto [offer, offerCreateError] = peerConnection->createPublishOffer(offer_config, media_config);
     if (offerCreateError.isError()) {
         std::cout << "Error: cannot create offer: " << offerCreateError.message << std::endl;
         exit(1);

--- a/tools/srtc_subscribe.cpp
+++ b/tools/srtc_subscribe.cpp
@@ -40,7 +40,6 @@ static bool gPrintSDP = false;
 static bool gPrintSenderReports = false;
 static std::string gOutputAudioFilename;
 static std::string gOutputVideoFilename;
-static bool gDropPackets = false;
 
 // Signals
 
@@ -73,7 +72,6 @@ void printUsage(const char* programName)
     std::cout << "  -s, --sdp            Print SDP offer and answer" << std::endl;
     std::cout << "  --oa <filename>      Save audio to a file (ogg format for opus)" << std::endl;
     std::cout << "  --ov <filename>      Save video to a file (h264 or webm format)" << std::endl;
-    std::cout << "  -d, --drop           Drop some packets at random (test NACK and RTX handling)" << std::endl;
     std::cout << "  -h, --help           Show this help message" << std::endl;
 }
 
@@ -220,8 +218,6 @@ int main(int argc, char* argv[])
                 std::cerr << "Error: --ov requires a filename" << std::endl;
                 return 1;
             }
-        } else if (arg == "-d" || arg == "--drop") {
-            gDropPackets = true;
         } else {
             std::cerr << "Unknown option: " << arg << std::endl;
             printUsage(argv[0]);
@@ -296,40 +292,49 @@ int main(int argc, char* argv[])
     // Offer
     SubOfferConfig offerConfig = {};
     offerConfig.cname = "foo";
-    offerConfig.debug_drop_packets = gDropPackets;
 
-    SubVideoCodec videoCodecVP8 = {};
+    SubCodec videoCodecVP8 = {};
     videoCodecVP8.codec = Codec::VP8;
 
-    SubVideoCodec videoCodecVP9 = {};
+    SubCodec videoCodecVP9 = {};
     videoCodecVP9.codec = Codec::VP9;
 
-    SubVideoCodec videoCodecH264 = {};
+    SubCodec videoCodecH264 = {};
     videoCodecH264.codec = Codec::H264;
     videoCodecH264.profile_level_id = 0x42e01f;
 
-    SubVideoCodec videoCodecH265 = {};
+    SubCodec videoCodecH265 = {};
     videoCodecH265.codec = Codec::H265;
 
-    SubVideoCodec videoCodecAV1 = {};
+    SubCodec videoCodecAV1 = {};
     videoCodecAV1.codec = Codec::AV1;
 
-    SubVideoConfig videoConfig = {};
-    videoConfig.codec_list.push_back(videoCodecVP8);
-    videoConfig.codec_list.push_back(videoCodecVP9);
-    videoConfig.codec_list.push_back(videoCodecH264);
-    videoConfig.codec_list.push_back(videoCodecH265);
-    videoConfig.codec_list.push_back(videoCodecAV1);
+    SubMediaItem videoMediaItem = {};
+    videoMediaItem.media_id = "video_0";
+    videoMediaItem.media_type = MediaType::Video;
 
-    SubAudioCodec audioCodec = {};
+    videoMediaItem.codec_list.push_back(videoCodecVP8);
+    videoMediaItem.codec_list.push_back(videoCodecVP9);
+    videoMediaItem.codec_list.push_back(videoCodecH264);
+    videoMediaItem.codec_list.push_back(videoCodecH265);
+    videoMediaItem.codec_list.push_back(videoCodecAV1);
+
+    SubCodec audioCodec = {};
     audioCodec.codec = Codec::Opus;
     audioCodec.minptime = 20;
     audioCodec.stereo = true;
 
-    SubAudioConfig audioConfig = {};
-    audioConfig.codec_list.push_back(audioCodec);
+    SubMediaItem audioMediaItem = {};
+    audioMediaItem.media_id = "audio_0";
+    audioMediaItem.media_type = MediaType::Audio;
 
-    const auto [offer, offerCreateError] = peerConnection->createSubscribeOffer(offerConfig, videoConfig, audioConfig);
+    audioMediaItem.codec_list.push_back(audioCodec);
+
+    SubMediaConfig subMediaConfig = {};
+    subMediaConfig.media_list.push_back(videoMediaItem);
+    subMediaConfig.media_list.push_back(audioMediaItem);
+
+    const auto [offer, offerCreateError] = peerConnection->createSubscribeOffer(offerConfig, subMediaConfig);
     if (offerCreateError.isError()) {
         std::cout << "Error: cannot create offer: " << offerCreateError.message << std::endl;
         exit(1);
@@ -357,20 +362,31 @@ int main(int argc, char* argv[])
         exit(1);
     }
 
+    // Tracks
+    std::shared_ptr<Track> trackAudio;
+    std::shared_ptr<Track> trackVideo;
+
+    for (const auto& track : answer->getTrackList()) {
+        if (track->getMediaType() == MediaType::Audio) {
+            trackAudio = track;
+        } else if (track->getMediaType() == MediaType::Video) {
+            trackVideo = track;
+        }
+    }
+
     // Media writers
     std::shared_ptr<MediaWriter> mediaWriterAudio;
     std::shared_ptr<MediaWriter> mediaWriterVideo;
 
     if (!gOutputAudioFilename.empty()) {
-        const auto track = answer->getAudioTrack();
-        if (!track) {
+        if (!trackAudio) {
             std::cout << "Saving audio output is requested, but there is no audio track" << std::endl;
             exit(1);
         }
 
-        const auto codec = track->getCodec();
+        const auto codec = trackAudio->getCodec();
         if (codec == Codec::Opus) {
-            mediaWriterAudio = std::make_shared<MediaWriterOgg>(gOutputAudioFilename, track);
+            mediaWriterAudio = std::make_shared<MediaWriterOgg>(gOutputAudioFilename, trackAudio);
             mediaWriterAudio->start();
         } else {
             std::cout << "Saving audio output is requested, but the audio codec is not one we support" << std::endl;
@@ -379,24 +395,23 @@ int main(int argc, char* argv[])
     }
 
     if (!gOutputVideoFilename.empty()) {
-        const auto track = answer->getVideoSingleTrack();
-        if (!track) {
+        if (!trackVideo) {
             std::cout << "Saving audio output is requested, but there is no video track" << std::endl;
             exit(1);
         }
 
-        const auto codec = track->getCodec();
+        const auto codec = trackVideo->getCodec();
         if (codec == Codec::VP8) {
-            mediaWriterVideo = std::make_shared<MediaWriterVP8>(gOutputVideoFilename, track);
+            mediaWriterVideo = std::make_shared<MediaWriterVP8>(gOutputVideoFilename, trackVideo);
             mediaWriterVideo->start();
         } else if (codec == Codec::VP9) {
-            mediaWriterVideo = std::make_shared<MediaWriterVP9>(gOutputVideoFilename, track);
+            mediaWriterVideo = std::make_shared<MediaWriterVP9>(gOutputVideoFilename, trackVideo);
             mediaWriterVideo->start();
         } else if (codec == Codec::H264 || codec == Codec::H265) {
-            mediaWriterVideo = std::make_shared<MediaWriterH26x>(gOutputVideoFilename, track);
+            mediaWriterVideo = std::make_shared<MediaWriterH26x>(gOutputVideoFilename, trackVideo);
             mediaWriterVideo->start();
         } else if (codec == Codec::AV1) {
-            mediaWriterVideo = std::make_shared<MediaWriterAV1>(gOutputVideoFilename, track);
+            mediaWriterVideo = std::make_shared<MediaWriterAV1>(gOutputVideoFilename, trackVideo);
             mediaWriterVideo->start();
         } else {
             std::cout << "Saving video output is requested, but the video codec is not one we support" << std::endl;

--- a/tools/srtc_subscribe.cpp
+++ b/tools/srtc_subscribe.cpp
@@ -14,6 +14,7 @@
 #include "media_writer_vp9.h"
 
 #include "http_whip_whep.h"
+#include "srtc/media.h"
 
 #include <csignal>
 #include <iomanip>
@@ -106,7 +107,8 @@ void printSenderReport(const std::shared_ptr<srtc::Track>& track, const srtc::Se
     static SenderReportState stateAudio;
     static SenderReportState stateVideo;
 
-    const auto type = track->getMediaType();
+    const auto media = track->getMedia();
+    const auto type = media->getType();
 
     const char* label;
     SenderReportState* state;
@@ -416,12 +418,13 @@ int main(int argc, char* argv[])
                 std::cout << "*** Received " << frameCount << " frames of audio / video media" << std::endl;
             }
 
-            const auto mediaType = frame->track->getMediaType();
-            if (mediaType == MediaType::Audio) {
+            const auto media = frame->track->getMedia();
+            const auto type = media->getType();
+            if (type == MediaType::Audio) {
                 if (mediaWriterAudio) {
                     mediaWriterAudio->send(frame);
                 }
-            } else if (mediaType == MediaType::Video) {
+            } else if (type == MediaType::Video) {
                 if (mediaWriterVideo) {
                     mediaWriterVideo->send(frame);
                 }


### PR DESCRIPTION
Allow multiple application - configured "media lines" e.g. multiple video tracks or audio tracks.

Refactor the API for publishing, got rid of special methods for simulcast.
