### PR TITLE
RRTR / DLRR fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ add_library(srtc
         include/srtc/receiver_reference_time_reports_history.h
         include/srtc/replay_protection.h
         include/srtc/rtcp_packet.h
+        include/srtc/rtcp_packet_multi.h
         include/srtc/rtcp_packet_source.h
         include/srtc/rtp_extension.h
         include/srtc/rtp_extension_builder.h
@@ -154,6 +155,7 @@ add_library(srtc
         src/receiver_reference_time_reports_history.cpp
         src/replay_protection.cpp
         src/rtcp_packet.cpp
+        src/rtcp_packet_multi.cpp
         src/rtcp_packet_source.cpp
         src/rtp_extension.cpp
         src/rtp_extension_builder.cpp

--- a/include/srtc/peer_candidate.h
+++ b/include/srtc/peer_candidate.h
@@ -57,6 +57,7 @@ class PeerCandidate final : sctp::SctpSessionListener
 {
 public:
     PeerCandidate(PeerCandidateListener* listener,
+                  Direction direction,
                   const std::shared_ptr<SdpOffer>& offer,
                   const std::shared_ptr<SdpAnswer>& answer,
                   uint32_t dataChannelMaxMessageSize,
@@ -72,8 +73,8 @@ public:
         int64_t pts_usec;
         std::shared_ptr<Track> track;
         std::shared_ptr<Packetizer> packetizer;
-        ByteBuffer buf;                      // possibly empty
-        std::vector<ByteBuffer> csd;         // possibly empty
+        ByteBuffer buf;              // possibly empty
+        std::vector<ByteBuffer> csd; // possibly empty
     };
     void addSendFrame(FrameToSend&& frame);
 
@@ -106,7 +107,6 @@ private:
     void addSendRaw(ByteBuffer&& buf);
     void flushSendRaw();
 
-
     void onReceivedStunMessage(const Socket::ReceivedData& data);
     void onReceivedDtlsMessage(ByteBuffer&& buf);
     void onReceivedRtcMessage(ByteBuffer&& buf);
@@ -133,6 +133,7 @@ private:
 
     PeerCandidateListener* const mListener;
 
+    const Direction mDirection;
     const std::vector<std::shared_ptr<Track>> mTrackList;
     const std::shared_ptr<SdpOffer> mOffer;
     const std::shared_ptr<SdpAnswer> mAnswer;

--- a/include/srtc/peer_candidate.h
+++ b/include/srtc/peer_candidate.h
@@ -37,6 +37,7 @@ class IceAgent;
 class SendRtpHistory;
 class SrtpConnection;
 class RtcpPacket;
+class RtcpPacketMulti;
 class EventLoop;
 class RtpExtensionSourceSimulcast;
 class RtpExtensionSourceTWCC;
@@ -126,7 +127,8 @@ private:
     void forgetExpiredStunRequests();
 
     void sendRtcpPacket(const std::shared_ptr<Track>& track, const std::shared_ptr<RtcpPacket>& packet);
-    void sendRtcpPacket(const std::shared_ptr<RtcpPacketSource>& track, const std::shared_ptr<RtcpPacket>& packet);
+    void sendRtcpPacket(const std::shared_ptr<RtcpPacketSource>& source, const std::shared_ptr<RtcpPacket>& packet);
+    void sendRtcpPacket(const std::shared_ptr<RtcpPacketSource>& source, const std::shared_ptr<RtcpPacketMulti>& packet);
 
     [[nodiscard]] std::shared_ptr<Track> findReceiveTrack(uint32_t ssrc) const;
     [[nodiscard]] std::shared_ptr<Track> findReceiveTrack(ByteBuffer& packet) const;

--- a/include/srtc/peer_candidate.h
+++ b/include/srtc/peer_candidate.h
@@ -57,7 +57,6 @@ class PeerCandidate final : sctp::SctpSessionListener
 {
 public:
     PeerCandidate(PeerCandidateListener* listener,
-                  const std::vector<std::shared_ptr<Track>>& trackList,
                   const std::shared_ptr<SdpOffer>& offer,
                   const std::shared_ptr<SdpAnswer>& answer,
                   uint32_t dataChannelMaxMessageSize,
@@ -149,8 +148,6 @@ private:
     const std::shared_ptr<RtpResponderTWCC> mResponderTWCC;
     const std::shared_ptr<SenderReportsHistory> mSenderReportsHistory;
     const std::shared_ptr<ReceiverReferenceTimeReportsHistory> mReceiverReferenceTimeReportsHistory;
-
-    RandomGenerator<uint32_t> mControlRandomGenerator;
     const std::shared_ptr<RtcpPacketSource> mControlPacketSource;
 
     Filter<float> mIceRttFilter;

--- a/include/srtc/rtcp_packet.h
+++ b/include/srtc/rtcp_packet.h
@@ -33,7 +33,7 @@ public:
 
     [[nodiscard]] ByteBuffer generate() const;
 
-    static std::list<std::shared_ptr<RtcpPacket>> fromUdpPacket(const srtc::ByteBuffer& data);
+    static std::list<std::shared_ptr<RtcpPacket>> fromUdpPacket(const ByteBuffer& data);
 
 private:
     const uint32_t mSSRC;

--- a/include/srtc/rtcp_packet_multi.h
+++ b/include/srtc/rtcp_packet_multi.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "srtc/byte_buffer.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace srtc
+{
+
+class RtcpPacket;
+class ByteBuffer;
+
+class RtcpPacketMulti
+{
+public:
+    RtcpPacketMulti(const std::vector<std::shared_ptr<RtcpPacket>>& packetList);
+    ~RtcpPacketMulti();
+
+    [[nodiscard]] ByteBuffer generate() const;
+
+private:
+    const ByteBuffer mMulti;
+};
+
+} // namespace srtc

--- a/include/srtc/sdp_offer.h
+++ b/include/srtc/sdp_offer.h
@@ -20,6 +20,7 @@ class PeerConnection;
 class PeerCandidate;
 class SendPacer;
 class X509Certificate;
+class RtcpPacketSource;
 
 struct DataChannelConfig {
     std::vector<std::string> data_channels;
@@ -111,6 +112,8 @@ public:
     [[nodiscard]] uint16_t getSctpPort() const;
     [[nodiscard]] uint32_t getSctpMaxMessageSize() const;
 
+    [[nodiscard]] std::shared_ptr<RtcpPacketSource> getControlPacketSource() const;
+
 private:
     std::string generateRandomUUID();
     std::string generateRandomString(size_t len);
@@ -154,6 +157,7 @@ private:
     };
 
     std::vector<MediaLineGenerated> mMediaLineGeneratedList;
+    std::shared_ptr<RtcpPacketSource> mControlPacketSource;
 };
 
 } // namespace srtc

--- a/src/peer_candidate.cpp
+++ b/src/peer_candidate.cpp
@@ -218,6 +218,7 @@ PeerCandidate::~PeerCandidate()
 }
 
 PeerCandidate::PeerCandidate(PeerCandidateListener* const listener,
+                             Direction direction,
                              const std::shared_ptr<SdpOffer>& offer,
                              const std::shared_ptr<SdpAnswer>& answer,
                              const uint32_t dataChannelMaxMessageSize,
@@ -226,6 +227,7 @@ PeerCandidate::PeerCandidate(PeerCandidateListener* const listener,
                              const std::shared_ptr<EventLoop>& eventLoop,
                              const Scheduler::Delay& startDelay)
     : mListener(listener)
+    , mDirection(direction)
     , mTrackList(answer->getTrackList())
     , mOffer(offer)
     , mAnswer(answer)
@@ -303,41 +305,43 @@ void PeerCandidate::addSendFrame(FrameToSend&& frame)
 
 void PeerCandidate::sendPublishReports()
 {
-    for (const auto& track : mTrackList) {
-        if (track->getDirection() == Direction::Publish) {
-            const auto ssrc = track->getSSRC();
-            const auto stats = track->getStats();
+    if (mDirection == Direction::Publish) {
+        for (const auto& track : mTrackList) {
+            if (track->getDirection() == Direction::Publish) {
+                const auto ssrc = track->getSSRC();
+                const auto stats = track->getStats();
 
-            NtpTime ntp = {};
-            getNtpTime(ntp);
+                NtpTime ntp = {};
+                getNtpTime(ntp);
 
-            // Sender Report
-            // https://www4.cs.fau.de/Projects/JRTP/pmt/node83.html
-            {
-                const auto timeSource = track->getRtpTimeSource();
-                const auto rtpTime = timeSource->getCurrentTimestamp();
+                // Sender Report
+                // https://www4.cs.fau.de/Projects/JRTP/pmt/node83.html
+                {
+                    const auto timeSource = track->getRtpTimeSource();
+                    const auto rtpTime = timeSource->getCurrentTimestamp();
 
-                ByteBuffer payload;
-                ByteWriter w(payload);
+                    ByteBuffer payload;
+                    ByteWriter w(payload);
 
-                w.writeU32(ntp.seconds);
-                w.writeU32(ntp.fraction);
-                w.writeU32(rtpTime);
+                    w.writeU32(ntp.seconds);
+                    w.writeU32(ntp.fraction);
+                    w.writeU32(rtpTime);
 
-                w.writeU32(static_cast<uint32_t>(stats->getSentPackets()));
-                w.writeU32(static_cast<uint32_t>(stats->getSentBytes()));
+                    w.writeU32(static_cast<uint32_t>(stats->getSentPackets()));
+                    w.writeU32(static_cast<uint32_t>(stats->getSentBytes()));
 
-                const auto packet =
-                    std::make_shared<RtcpPacket>(ssrc, 0, RtcpPacket::kSenderReport, std::move(payload));
-                sendRtcpPacket(track, packet);
+                    const auto packet =
+                        std::make_shared<RtcpPacket>(ssrc, 0, RtcpPacket::kSenderReport, std::move(payload));
+                    sendRtcpPacket(track, packet);
 
-                mSenderReportsHistory->save(ssrc, ntp);
+                    mSenderReportsHistory->save(ssrc, ntp);
+                }
             }
         }
     }
 
-    if (!mOutstandingReceiverReferenceTimeReportList.empty()) {
-        // XR - DLRR if we have received RTRR
+    if (mDirection == Direction::Publish && !mOutstandingReceiverReferenceTimeReportList.empty()) {
+        // XR - DLRR if we have received RTRR's
         // https://datatracker.ietf.org/doc/html/rfc3611#section-4.5
 
         ByteBuffer payload;
@@ -368,9 +372,8 @@ void PeerCandidate::sendPublishReports()
 
 void PeerCandidate::sendSubscribeReports()
 {
-    // Receiver Reports
-
-    {
+    if (mDirection == Direction::Subscribe) {
+        // Receiver Reports
         ByteBuffer payload;
         ByteWriter w(payload);
 
@@ -416,41 +419,29 @@ void PeerCandidate::sendSubscribeReports()
         }
     }
 
-    // RRTR
-    // https://datatracker.ietf.org/doc/html/rfc3611#section-4.4
+    if (mDirection == Direction::Subscribe) {
+        // RRTR
+        // https://datatracker.ietf.org/doc/html/rfc3611#section-4.4
+        NtpTime ntp = {};
+        getNtpTime(ntp);
 
-    {
-        for (const auto& track : mTrackList) {
-            if (track->getDirection() == Direction::Subscribe) {
-                NtpTime ntp = {};
-                getNtpTime(ntp);
+        ByteBuffer payload;
+        ByteWriter w(payload);
 
-                ByteBuffer payload;
-                ByteWriter w(payload);
+        w.writeU8(4);
+        w.writeU8(0);
+        w.writeU16(2);
+        w.writeU32(ntp.seconds);
+        w.writeU32(ntp.fraction);
 
-                w.writeU8(4);
-                w.writeU8(0);
-                w.writeU16(2);
-                w.writeU32(ntp.seconds);
-                w.writeU32(ntp.fraction);
+        const auto source = mControlPacketSource;
+        const auto packet =
+            std::make_shared<RtcpPacket>(source->getSSRC(), 0, RtcpPacket::kExtendedReport, std::move(payload));
+        sendRtcpPacket(source, packet);
 
-                const auto source = mControlPacketSource;
-                const auto packet =
-                    std::make_shared<RtcpPacket>(source->getSSRC(), 0, RtcpPacket::kExtendedReport, std::move(payload));
-                sendRtcpPacket(source, packet);
+        mReceiverReferenceTimeReportsHistory->save(packet->getSSRC(), ntp);
 
-                mReceiverReferenceTimeReportsHistory->save(packet->getSSRC(), ntp);
-
-                LOG(SRTC_LOG_Z,
-                    "*** Sending RRTR: ssrc = %u ntp = %8x:%8x",
-                    packet->getSSRC(),
-                    ntp.seconds,
-                    ntp.fraction);
-
-                // Just one is all we need
-                break;
-            }
-        }
+        LOG(SRTC_LOG_Z, "*** Sending RRTR: ssrc = %u ntp = %8x:%8x", packet->getSSRC(), ntp.seconds, ntp.fraction);
     }
 }
 

--- a/src/peer_candidate.cpp
+++ b/src/peer_candidate.cpp
@@ -15,6 +15,7 @@
 #include "srtc/receiver_reference_time_report.h"
 #include "srtc/receiver_reference_time_reports_history.h"
 #include "srtc/rtcp_packet.h"
+#include "srtc/rtcp_packet_multi.h"
 #include "srtc/rtcp_packet_source.h"
 #include "srtc/rtp_extension_builder.h"
 #include "srtc/rtp_extension_source_simulcast.h"
@@ -372,6 +373,9 @@ void PeerCandidate::sendPublishReports()
 
 void PeerCandidate::sendSubscribeReports()
 {
+    const auto source = mControlPacketSource;
+    std::vector<std::shared_ptr<RtcpPacket>> packetList;
+
     if (mDirection == Direction::Subscribe) {
         // Receiver Reports
         ByteBuffer payload;
@@ -412,10 +416,9 @@ void PeerCandidate::sendSubscribeReports()
         }
 
         if (!payload.empty()) {
-            const auto source = mControlPacketSource;
             const auto packet = std::make_shared<RtcpPacket>(
                 source->getSSRC(), reportCount, RtcpPacket::kReceiverReport, std::move(payload));
-            sendRtcpPacket(source, packet);
+            packetList.push_back(packet);
         }
     }
 
@@ -434,14 +437,16 @@ void PeerCandidate::sendSubscribeReports()
         w.writeU32(ntp.seconds);
         w.writeU32(ntp.fraction);
 
-        const auto source = mControlPacketSource;
         const auto packet =
             std::make_shared<RtcpPacket>(source->getSSRC(), 0, RtcpPacket::kExtendedReport, std::move(payload));
-        sendRtcpPacket(source, packet);
+        packetList.push_back(packet);
 
         mReceiverReferenceTimeReportsHistory->save(packet->getSSRC(), ntp);
+    }
 
-        LOG(SRTC_LOG_Z, "*** Sending RRTR: ssrc = %u ntp = %8x:%8x", packet->getSSRC(), ntp.seconds, ntp.fraction);
+    if (!packetList.empty()) {
+        const auto multi = std::make_shared<RtcpPacketMulti>(packetList);
+        sendRtcpPacket(source, multi);
     }
 }
 
@@ -1336,8 +1341,6 @@ void PeerCandidate::onReceivedControlMessage_DLRR([[maybe_unused]] uint32_t ssrc
         const auto ntpMiddle = rtcpReader.readU32();
         const auto delay = rtcpReader.readU32();
 
-        LOG(SRTC_LOG_Z, "*** Received DLRR: ssrc = %u, ntp = %8x", ssrc1, ntpMiddle);
-
         if (ntpMiddle != 0u) {
             const auto rtt = mReceiverReferenceTimeReportsHistory->calculateRtt(ssrc1, ntpMiddle, delay);
             if (rtt.has_value()) {
@@ -1363,6 +1366,19 @@ void PeerCandidate::sendRtcpPacket(const std::shared_ptr<Track>& track, const st
 
 void PeerCandidate::sendRtcpPacket(const std::shared_ptr<RtcpPacketSource>& source,
                                    const std::shared_ptr<RtcpPacket>& packet)
+{
+    if (mSrtpConnection) {
+        const auto packetData = packet->generate();
+
+        if (mSrtpConnection->protectSendControl(packetData, source->getNextSequence(), mProtectedBuf)) {
+            const auto w = mSocket->send(mProtectedBuf.data(), mProtectedBuf.size());
+            LOG(SRTC_LOG_V, "Sent %zu bytes of RTCP", w);
+        }
+    }
+}
+
+void PeerCandidate::sendRtcpPacket(const std::shared_ptr<RtcpPacketSource>& source,
+                                   const std::shared_ptr<RtcpPacketMulti>& packet)
 {
     if (mSrtpConnection) {
         const auto packetData = packet->generate();

--- a/src/peer_candidate.cpp
+++ b/src/peer_candidate.cpp
@@ -208,8 +208,16 @@ float calculateLayerBandwidthScale(const std::vector<srtc::SimulcastLayer>& laye
 namespace srtc
 {
 
+PeerCandidate::~PeerCandidate()
+{
+    LOG(SRTC_LOG_V, "Destructor for %p #%d", static_cast<void*>(this), mUniqueId);
+
+    mEventLoop->unregisterSocket(mSocket);
+
+    freeDTLS();
+}
+
 PeerCandidate::PeerCandidate(PeerCandidateListener* const listener,
-                             const std::vector<std::shared_ptr<Track>>& trackList,
                              const std::shared_ptr<SdpOffer>& offer,
                              const std::shared_ptr<SdpAnswer>& answer,
                              const uint32_t dataChannelMaxMessageSize,
@@ -218,7 +226,7 @@ PeerCandidate::PeerCandidate(PeerCandidateListener* const listener,
                              const std::shared_ptr<EventLoop>& eventLoop,
                              const Scheduler::Delay& startDelay)
     : mListener(listener)
-    , mTrackList(trackList)
+    , mTrackList(answer->getTrackList())
     , mOffer(offer)
     , mAnswer(answer)
     , mHost(host)
@@ -233,8 +241,7 @@ PeerCandidate::PeerCandidate(PeerCandidateListener* const listener,
     , mResponderTWCC(RtpResponderTWCC::factory(offer))
     , mSenderReportsHistory(std::make_shared<SenderReportsHistory>())
     , mReceiverReferenceTimeReportsHistory(std::make_shared<ReceiverReferenceTimeReportsHistory>())
-    , mControlRandomGenerator(1, 0xFFFFFFFFu)
-    , mControlPacketSource(std::make_shared<RtcpPacketSource>(mControlRandomGenerator.next()))
+    , mControlPacketSource(offer->getControlPacketSource())
     , mIceRttFilter(0.2f)
     , mControlRttFilter(0.2f)
     , mSentUseCandidate(false)
@@ -278,15 +285,6 @@ PeerCandidate::PeerCandidate(PeerCandidateListener* const listener,
 
     mTaskExpireStunRequests =
         mScheduler.submit(kExpireStunPeriod, __FILE__, __LINE__, [this] { forgetExpiredStunRequests(); });
-}
-
-PeerCandidate::~PeerCandidate()
-{
-    LOG(SRTC_LOG_V, "Destructor for %p #%d", static_cast<void*>(this), mUniqueId);
-
-    mEventLoop->unregisterSocket(mSocket);
-
-    freeDTLS();
 }
 
 void PeerCandidate::receiveFromSocket()
@@ -441,10 +439,13 @@ void PeerCandidate::sendSubscribeReports()
                     std::make_shared<RtcpPacket>(source->getSSRC(), 0, RtcpPacket::kExtendedReport, std::move(payload));
                 sendRtcpPacket(source, packet);
 
-                mReceiverReferenceTimeReportsHistory->save(source->getSSRC(), ntp);
+                mReceiverReferenceTimeReportsHistory->save(packet->getSSRC(), ntp);
 
-                // LOG(SRTC_LOG_Z, "*** Sending RRTR: ssrc = %u ntp = %8x:%8x", source->getSSRC(), ntp.seconds,
-                // ntp.fraction);
+                LOG(SRTC_LOG_Z,
+                    "*** Sending RRTR: ssrc = %u ntp = %8x:%8x",
+                    packet->getSSRC(),
+                    ntp.seconds,
+                    ntp.fraction);
 
                 // Just one is all we need
                 break;
@@ -1344,7 +1345,7 @@ void PeerCandidate::onReceivedControlMessage_DLRR([[maybe_unused]] uint32_t ssrc
         const auto ntpMiddle = rtcpReader.readU32();
         const auto delay = rtcpReader.readU32();
 
-        // LOG(SRTC_LOG_Z, "*** Received DLRR: ssrc = %u, ntp = %8x", ssrc1, ntpMiddle);
+        LOG(SRTC_LOG_Z, "*** Received DLRR: ssrc = %u, ntp = %8x", ssrc1, ntpMiddle);
 
         if (ntpMiddle != 0u) {
             const auto rtt = mReceiverReferenceTimeReportsHistory->calculateRtt(ssrc1, ntpMiddle, delay);

--- a/src/peer_candidate.cpp
+++ b/src/peer_candidate.cpp
@@ -209,15 +209,6 @@ float calculateLayerBandwidthScale(const std::vector<srtc::SimulcastLayer>& laye
 namespace srtc
 {
 
-PeerCandidate::~PeerCandidate()
-{
-    LOG(SRTC_LOG_V, "Destructor for %p #%d", static_cast<void*>(this), mUniqueId);
-
-    mEventLoop->unregisterSocket(mSocket);
-
-    freeDTLS();
-}
-
 PeerCandidate::PeerCandidate(PeerCandidateListener* const listener,
                              Direction direction,
                              const std::shared_ptr<SdpOffer>& offer,
@@ -288,6 +279,15 @@ PeerCandidate::PeerCandidate(PeerCandidateListener* const listener,
 
     mTaskExpireStunRequests =
         mScheduler.submit(kExpireStunPeriod, __FILE__, __LINE__, [this] { forgetExpiredStunRequests(); });
+}
+
+PeerCandidate::~PeerCandidate()
+{
+    LOG(SRTC_LOG_V, "Destructor for %p #%d", static_cast<void*>(this), mUniqueId);
+
+    mEventLoop->unregisterSocket(mSocket);
+
+    freeDTLS();
 }
 
 void PeerCandidate::receiveFromSocket()

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -746,9 +746,6 @@ void PeerConnection::startConnecting()
 
     mFrameSendQueue.clear();
 
-    // We will need the track list
-    const auto trackList = collectTracks();
-
     // Interleave IPv4 and IPv6 candidates
     std::vector<Host> hostList4;
     std::vector<Host> hostList6;
@@ -767,7 +764,6 @@ void PeerConnection::startConnecting()
         if (i < hostList4.size()) {
             const auto listener = static_cast<PeerCandidateListener*>(this);
             const auto candidate = std::make_shared<PeerCandidate>(listener,
-                                                                   trackList,
                                                                    mSdpOffer,
                                                                    mSdpAnswer,
                                                                    mDataChannelMaxMessageSize,
@@ -780,7 +776,6 @@ void PeerConnection::startConnecting()
         if (i < hostList6.size()) {
             const auto listener = static_cast<PeerCandidateListener*>(this);
             const auto candidate = std::make_shared<PeerCandidate>(listener,
-                                                                   trackList,
                                                                    mSdpOffer,
                                                                    mSdpAnswer,
                                                                    mDataChannelMaxMessageSize,

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -764,6 +764,7 @@ void PeerConnection::startConnecting()
         if (i < hostList4.size()) {
             const auto listener = static_cast<PeerCandidateListener*>(this);
             const auto candidate = std::make_shared<PeerCandidate>(listener,
+                                                                   mDirection,
                                                                    mSdpOffer,
                                                                    mSdpAnswer,
                                                                    mDataChannelMaxMessageSize,
@@ -776,6 +777,7 @@ void PeerConnection::startConnecting()
         if (i < hostList6.size()) {
             const auto listener = static_cast<PeerCandidateListener*>(this);
             const auto candidate = std::make_shared<PeerCandidate>(listener,
+                                                                   mDirection,
                                                                    mSdpOffer,
                                                                    mSdpAnswer,
                                                                    mDataChannelMaxMessageSize,
@@ -1122,8 +1124,10 @@ void PeerConnection::sendPeriodicPictureLossIndicators()
             const auto interval = std::clamp<uint16_t>(config.pli_interval_millis, 500u, 4000u);
 
             Task::cancelHelper(mTaskPictureLossIndicator);
-            mTaskPictureLossIndicator = mLoopScheduler->submit(
-                std::chrono::milliseconds(interval), __FILE__, __LINE__, [this] { sendPeriodicPictureLossIndicators(); });
+            mTaskPictureLossIndicator =
+                mLoopScheduler->submit(std::chrono::milliseconds(interval), __FILE__, __LINE__, [this] {
+                    sendPeriodicPictureLossIndicators();
+                });
 
             if (mConnectionState != ConnectionState::Connected) {
                 return;

--- a/src/receiver_reference_time_reports_history.cpp
+++ b/src/receiver_reference_time_reports_history.cpp
@@ -30,21 +30,24 @@ std::optional<float> ReceiverReferenceTimeReportsHistory::calculateRtt(uint32_t 
 {
 	const auto trackIter = mTrackMap.find(ssrc);
 	if (trackIter != mTrackMap.end()) {
-		const auto& trackItem = trackIter->second;
-		for (const auto& item : trackItem.reportList) {
-			const auto middle = getNtpTimeMiddleMarker(item.ntp);
+		auto& trackItem = trackIter->second;
+		for (auto iter = trackItem.reportList.begin(); iter != trackItem.reportList.end(); ++iter) {
+			const auto middle = getNtpTimeMiddleMarker(iter->ntp);
 			if (middle == ntpMarker) {
 				const auto delayMicros = static_cast<int64_t>(delay) * 1000000 / 65536;
 				const auto now = std::chrono::steady_clock::now();
-				const auto received = item.sent + std::chrono::microseconds(delayMicros);
+				const auto received = iter->sent + std::chrono::microseconds(delayMicros);
 
+				std::optional<float> result;
 				if (now >= received) {
 					// The 2 is so we get the actual back-and-forth (roundtrip) value
-					return 2 * 1 / 1000.0f *
-						   static_cast<float>(
-							   std::chrono::duration_cast<std::chrono::microseconds>(now - received).count());
+					result = 2 * 1 / 1000.0f *
+							 static_cast<float>(
+								 std::chrono::duration_cast<std::chrono::microseconds>(now - received).count());
 				}
-				break;
+
+				trackItem.reportList.erase(iter);
+				return result;
 			}
 		}
 	}

--- a/src/receiver_reference_time_reports_history.cpp
+++ b/src/receiver_reference_time_reports_history.cpp
@@ -36,7 +36,6 @@ std::optional<float> ReceiverReferenceTimeReportsHistory::calculateRtt(uint32_t 
         for (auto iter = trackItem.reportList.begin(); iter != trackItem.reportList.end(); ++iter) {
             const auto middle = getNtpTimeMiddleMarker(iter->ntp);
             if (middle == ntpMarker) {
-                std::printf("*** Found a matching RRTR\n");
                 const auto delayMicros = static_cast<int64_t>(delay) * 1000000 / 65536;
                 const auto now = std::chrono::steady_clock::now();
                 const auto received = iter->sent + std::chrono::microseconds(delayMicros);
@@ -55,8 +54,6 @@ std::optional<float> ReceiverReferenceTimeReportsHistory::calculateRtt(uint32_t 
         }
     }
 
-    std::printf("*** Could not find a matching RRTR\n");
-F
     return std::nullopt;
 }
 

--- a/src/receiver_reference_time_reports_history.cpp
+++ b/src/receiver_reference_time_reports_history.cpp
@@ -18,41 +18,46 @@ ReceiverReferenceTimeReportsHistory::~ReceiverReferenceTimeReportsHistory() = de
 
 void ReceiverReferenceTimeReportsHistory::save(uint32_t ssrc, const NtpTime& ntp)
 {
-	auto& item = mTrackMap[ssrc];
-	while (item.reportList.size() >= kMaxHistory) {
-		item.reportList.pop_front();
-	}
+    auto& item = mTrackMap[ssrc];
+    while (item.reportList.size() >= kMaxHistory) {
+        item.reportList.pop_front();
+    }
 
-	item.reportList.emplace_back(ntp, std::chrono::steady_clock::now());
+    item.reportList.emplace_back(ntp, std::chrono::steady_clock::now());
 }
 
-std::optional<float> ReceiverReferenceTimeReportsHistory::calculateRtt(uint32_t ssrc, uint32_t ntpMarker, uint32_t delay)
+std::optional<float> ReceiverReferenceTimeReportsHistory::calculateRtt(uint32_t ssrc,
+                                                                       uint32_t ntpMarker,
+                                                                       uint32_t delay)
 {
-	const auto trackIter = mTrackMap.find(ssrc);
-	if (trackIter != mTrackMap.end()) {
-		auto& trackItem = trackIter->second;
-		for (auto iter = trackItem.reportList.begin(); iter != trackItem.reportList.end(); ++iter) {
-			const auto middle = getNtpTimeMiddleMarker(iter->ntp);
-			if (middle == ntpMarker) {
-				const auto delayMicros = static_cast<int64_t>(delay) * 1000000 / 65536;
-				const auto now = std::chrono::steady_clock::now();
-				const auto received = iter->sent + std::chrono::microseconds(delayMicros);
+    const auto trackIter = mTrackMap.find(ssrc);
+    if (trackIter != mTrackMap.end()) {
+        auto& trackItem = trackIter->second;
+        for (auto iter = trackItem.reportList.begin(); iter != trackItem.reportList.end(); ++iter) {
+            const auto middle = getNtpTimeMiddleMarker(iter->ntp);
+            if (middle == ntpMarker) {
+                std::printf("*** Found a matching RRTR\n");
+                const auto delayMicros = static_cast<int64_t>(delay) * 1000000 / 65536;
+                const auto now = std::chrono::steady_clock::now();
+                const auto received = iter->sent + std::chrono::microseconds(delayMicros);
 
-				std::optional<float> result;
-				if (now >= received) {
-					// The 2 is so we get the actual back-and-forth (roundtrip) value
-					result = 2 * 1 / 1000.0f *
-							 static_cast<float>(
-								 std::chrono::duration_cast<std::chrono::microseconds>(now - received).count());
-				}
+                trackItem.reportList.erase(iter);
 
-				trackItem.reportList.erase(iter);
-				return result;
-			}
-		}
-	}
+                if (now >= received) {
+                    // The 2 is so we get the actual back-and-forth (roundtrip) value
+                    return 2 * 1 / 1000.0f *
+                           static_cast<float>(
+                               std::chrono::duration_cast<std::chrono::microseconds>(now - received).count());
+                }
 
-	return std::nullopt;
+                return std::nullopt;
+            }
+        }
+    }
+
+    std::printf("*** Could not find a matching RRTR\n");
+F
+    return std::nullopt;
 }
 
 } // namespace srtc

--- a/src/rtcp_packet_multi.cpp
+++ b/src/rtcp_packet_multi.cpp
@@ -1,0 +1,37 @@
+#include "srtc/rtcp_packet_multi.h"
+#include "srtc/byte_buffer.h"
+#include "srtc/rtcp_packet.h"
+
+namespace
+{
+
+srtc::ByteBuffer combine(const std::vector<std::shared_ptr<srtc::RtcpPacket>>& packetList)
+{
+    srtc::ByteBuffer buf;
+    srtc::ByteWriter w(buf);
+
+    for (const auto& p : packetList) {
+        w.write(p->generate());
+    }
+
+    return buf;
+}
+
+} // namespace
+
+namespace srtc
+{
+
+RtcpPacketMulti::RtcpPacketMulti(const std::vector<std::shared_ptr<RtcpPacket>>& packetList)
+    : mMulti(combine(packetList))
+{
+}
+
+RtcpPacketMulti::~RtcpPacketMulti() = default;
+
+ByteBuffer RtcpPacketMulti::generate() const
+{
+    return mMulti.copy();
+}
+
+}; // namespace srtc

--- a/src/sdp_offer.cpp
+++ b/src/sdp_offer.cpp
@@ -5,6 +5,8 @@
 
 #include "srtc/rtp_std_extensions.h"
 #include "srtc/sdp_offer.h"
+
+#include "srtc/rtcp_packet_source.h"
 #include "srtc/x509_certificate.h"
 
 namespace
@@ -213,6 +215,10 @@ std::pair<std::string, Error> SdpOffer::generate()
 
             mediaLineGenerated.ssrc = 1 + mRandomGenerator.next();
 
+            if (!mControlPacketSource) {
+                mControlPacketSource = std::make_shared<RtcpPacketSource>(mediaLineGenerated.ssrc);
+            }
+
             ss << "a=ssrc:" << mediaLineGenerated.ssrc << " cname:" << mConfig.cname << std::endl;
             ss << "a=ssrc:" << mediaLineGenerated.ssrc << " msid:" << mConfig.cname << " " << msid << std::endl;
 
@@ -267,6 +273,10 @@ std::pair<std::string, Error> SdpOffer::generate()
 
                 ss << "a=ssrc:" << layerGenerated.ssrc << " cname:" << mConfig.cname << std::endl;
                 ss << "a=ssrc:" << layerGenerated.ssrc << " msid:" << mConfig.cname << " " << msid << std::endl;
+
+                if (!mControlPacketSource) {
+                    mControlPacketSource = std::make_shared<RtcpPacketSource>(layerGenerated.ssrc);
+                }
 
                 if (mConfig.enable_rtx) {
                     layerGenerated.rtx = 1 + mRandomGenerator.next();
@@ -368,6 +378,11 @@ uint16_t SdpOffer::getSctpPort() const
 uint32_t SdpOffer::getSctpMaxMessageSize() const
 {
     return kSctpMaxMessageSize;
+}
+
+std::shared_ptr<RtcpPacketSource> SdpOffer::getControlPacketSource() const
+{
+    return mControlPacketSource;
 }
 
 std::string SdpOffer::generateRandomUUID()

--- a/src/sender_reports_history.cpp
+++ b/src/sender_reports_history.cpp
@@ -18,41 +18,41 @@ SenderReportsHistory::~SenderReportsHistory() = default;
 
 void SenderReportsHistory::save(uint32_t ssrc, const NtpTime& ntp)
 {
-	auto& item = mTrackMap[ssrc];
-	while (item.reportList.size() >= kMaxHistory) {
-		item.reportList.pop_front();
-	}
+    auto& item = mTrackMap[ssrc];
+    while (item.reportList.size() >= kMaxHistory) {
+        item.reportList.pop_front();
+    }
 
-	item.reportList.emplace_back(ntp, std::chrono::steady_clock::now());
+    item.reportList.emplace_back(ntp, std::chrono::steady_clock::now());
 }
 
 std::optional<float> SenderReportsHistory::calculateRtt(uint32_t ssrc, uint32_t ntpMarker, uint32_t delay)
 {
-	const auto trackIter = mTrackMap.find(ssrc);
-	if (trackIter != mTrackMap.end()) {
-		auto& trackItem = trackIter->second;
-		for (auto iter = trackItem.reportList.begin(); iter != trackItem.reportList.end(); ++iter) {
-			const auto middle = getNtpTimeMiddleMarker(iter->ntp);
-			if (middle == ntpMarker) {
-				const auto delayMicros = static_cast<int64_t>(delay) * 1000000 / 65536;
-				const auto now = std::chrono::steady_clock::now();
-				const auto received = iter->sent + std::chrono::microseconds(delayMicros);
+    const auto trackIter = mTrackMap.find(ssrc);
+    if (trackIter != mTrackMap.end()) {
+        auto& trackItem = trackIter->second;
+        for (auto iter = trackItem.reportList.begin(); iter != trackItem.reportList.end(); ++iter) {
+            const auto middle = getNtpTimeMiddleMarker(iter->ntp);
+            if (middle == ntpMarker) {
+                const auto delayMicros = static_cast<int64_t>(delay) * 1000000 / 65536;
+                const auto now = std::chrono::steady_clock::now();
+                const auto received = iter->sent + std::chrono::microseconds(delayMicros);
 
-				std::optional<float> result;
-				if (now >= received) {
-					// The 2 is so we get the actual back-and-forth (roundtrip) value
-					result = 2 * 1 / 1000.0f *
-							 static_cast<float>(
-								 std::chrono::duration_cast<std::chrono::microseconds>(now - received).count());
-				}
+                trackItem.reportList.erase(iter);
 
-				trackItem.reportList.erase(iter);
-				return result;
-			}
-		}
-	}
+                if (now >= received) {
+                    // The 2 is so we get the actual back-and-forth (roundtrip) value
+                    return 2 * 1 / 1000.0f *
+                           static_cast<float>(
+                               std::chrono::duration_cast<std::chrono::microseconds>(now - received).count());
+                }
 
-	return std::nullopt;
+                return std::nullopt;
+            }
+        }
+    }
+
+    return std::nullopt;
 }
 
 } // namespace srtc

--- a/src/sender_reports_history.cpp
+++ b/src/sender_reports_history.cpp
@@ -30,21 +30,24 @@ std::optional<float> SenderReportsHistory::calculateRtt(uint32_t ssrc, uint32_t 
 {
 	const auto trackIter = mTrackMap.find(ssrc);
 	if (trackIter != mTrackMap.end()) {
-		const auto& trackItem = trackIter->second;
-		for (const auto& item : trackItem.reportList) {
-			const auto middle = getNtpTimeMiddleMarker(item.ntp);
+		auto& trackItem = trackIter->second;
+		for (auto iter = trackItem.reportList.begin(); iter != trackItem.reportList.end(); ++iter) {
+			const auto middle = getNtpTimeMiddleMarker(iter->ntp);
 			if (middle == ntpMarker) {
 				const auto delayMicros = static_cast<int64_t>(delay) * 1000000 / 65536;
 				const auto now = std::chrono::steady_clock::now();
-				const auto received = item.sent + std::chrono::microseconds(delayMicros);
+				const auto received = iter->sent + std::chrono::microseconds(delayMicros);
 
+				std::optional<float> result;
 				if (now >= received) {
 					// The 2 is so we get the actual back-and-forth (roundtrip) value
-					return 2 * 1 / 1000.0f *
-						   static_cast<float>(
-							   std::chrono::duration_cast<std::chrono::microseconds>(now - received).count());
+					result = 2 * 1 / 1000.0f *
+							 static_cast<float>(
+								 std::chrono::duration_cast<std::chrono::microseconds>(now - received).count());
 				}
-				break;
+
+				trackItem.reportList.erase(iter);
+				return result;
 			}
 		}
 	}


### PR DESCRIPTION
Most importantly - combine all subscribe side RTCP feedback into one UDP packet.

All because someone was too cheap to include a SSRC in the RRTR payload. Just two bytes.
